### PR TITLE
PyDemo: companion chart, backtester & portfolio study tools

### DIFF
--- a/tools/Python/PyDemo/.gitignore
+++ b/tools/Python/PyDemo/.gitignore
@@ -1,3 +1,6 @@
 config/config.yaml
 __pycache__/
 *.py[cod]
+
+# Runtime artifact: per-symbol chart drawings persisted by the chart window.
+config/chart_drawings.json

--- a/tools/Python/PyDemo/T4APIClient.py
+++ b/tools/Python/PyDemo/T4APIClient.py
@@ -465,13 +465,15 @@ class Client:
         # message carries no side, so we look it up from the cached order.
         if self.on_account_update:
             order = self.orders.get(trade_update.unique_id)
+            if order is None or not hasattr(order, "buy_sell"):
+                return  # can't infer side -> don't emit a misleading marker event
             self.on_account_update({
                 "type": "fill",
                 "market_id": trade_update.market_id,
                 "unique_id": trade_update.unique_id,
                 "price": trade_update.price.value if trade_update.HasField("price") else None,
                 "volume": getattr(trade_update, "volume", 0),
-                "buy_sell": getattr(order, "buy_sell", 0) if order else 0,
+                "buy_sell": getattr(order, "buy_sell"),
                 "time": trade_update.time.seconds if trade_update.HasField("time") else None,
             })
 

--- a/tools/Python/PyDemo/T4APIClient.py
+++ b/tools/Python/PyDemo/T4APIClient.py
@@ -18,6 +18,7 @@ class Client:
     #initializes core attributes
     def __init__(self, config):
         #config file settings
+        self.config = config   # retained so UI features can read optional blocks (e.g. portfolio_study)
         self.wsUrl = config['websocket']['url']
         self.apiUrl = config['websocket']['api']
         self.apiKey = None 
@@ -212,6 +213,11 @@ class Client:
         self.positions[key] = message
 
         # Convert proto to dict with default values and add P&L fields
+        avg_open_price = (
+            message.average_open_price.value
+            if message.HasField("average_open_price")
+            else None
+        )
         self.positions[key] = {
             "account_id": message.account_id,
             "exchange_id": message.exchange_id,
@@ -221,6 +227,9 @@ class Client:
             "sells": message.sells,
             "working_buys": message.working_buys,
             "working_sells": message.working_sells,
+            # net + average open price drive the chart's position overlay line
+            "net": message.buys - message.sells,
+            "average_open_price": avg_open_price,
             "upl": 0.0,
             "rpl": 0.0,
             "total_pnl": 0.0,
@@ -350,19 +359,43 @@ class Client:
                 if len(message.offers) > 0
                 else "-"
             )
+            has_trade = (
+                message.HasField("trade_data")
+                and message.trade_data.HasField("last_trade_price")
+            )
             last_trade = (
                 f"{message.trade_data.last_trade_volume}@{message.trade_data.last_trade_price.value}"
-                if message.HasField("trade_data") and message.trade_data.HasField("last_trade_price")
+                if has_trade
                 else "-"
+            )
+
+            # Numeric trade fields for the chart. total_traded_volume lets the
+            # chart de-dupe: market-depth updates re-send the same last trade on
+            # every bid/offer change, so the chart only aggregates volume when
+            # the cumulative traded volume advances.
+            last_trade_price = (
+                message.trade_data.last_trade_price.value if has_trade else None
+            )
+            last_trade_volume = (
+                message.trade_data.last_trade_volume if has_trade else 0
+            )
+            total_traded_volume = (
+                getattr(message.trade_data, "total_traded_volume", 0)
+                if message.HasField("trade_data")
+                else 0
             )
 
             self.on_market_update({
                 "market_id": message.market_id,
                 "contract_id": market_detail.contract_id,
+                "exchange_id": getattr(market_detail, "exchange_id", None),
                 "expiry_date": market_detail.expiry_date,
                 "best_bid": best_bid,
                 "best_offer": best_offer,
                 "last_trade": last_trade,
+                "last_trade_price": last_trade_price,
+                "last_trade_volume": last_trade_volume,
+                "total_traded_volume": total_traded_volume,
             })
 
     #subscriber response (debug)
@@ -428,6 +461,19 @@ class Client:
     #debug functions
     def handle_order_update_trade(self, trade_update):
         print(f"Trade update: {trade_update.unique_id}, trade: {trade_update.exchange_trade_id}")
+        # Emit a fill event so the chart can place a buy/sell marker. The trade
+        # message carries no side, so we look it up from the cached order.
+        if self.on_account_update:
+            order = self.orders.get(trade_update.unique_id)
+            self.on_account_update({
+                "type": "fill",
+                "market_id": trade_update.market_id,
+                "unique_id": trade_update.unique_id,
+                "price": trade_update.price.value if trade_update.HasField("price") else None,
+                "volume": getattr(trade_update, "volume", 0),
+                "buy_sell": getattr(order, "buy_sell", 0) if order else 0,
+                "time": trade_update.time.seconds if trade_update.HasField("time") else None,
+            })
 
     def handle_order_update_trade_leg(self, leg_update):
         print(f"Trade leg update: {leg_update.unique_id}, leg index: {leg_update.leg_index}")

--- a/tools/Python/PyDemo/backtest/__init__.py
+++ b/tools/Python/PyDemo/backtest/__init__.py
@@ -1,0 +1,20 @@
+"""PyDemo Backtester — a faithful Python port of JSDemo's single-instrument
+backtest engine, fed by live T4 bars.
+
+This package reimplements JSDemo's ``algo/`` backtest stack in Python so PyDemo
+runs the *same* strategies on the *same* data the chart shows — no outside CSV /
+Yahoo data, no sibling research package:
+
+- ``indicators`` — port of ``algo/strategies/indicators.js`` (scalar-returning,
+  buffer-based; Pine-seeded MACD, Wilder RSI).
+- ``portfolio`` — port of ``algo/Portfolio.js`` (position/PnL accounting, equity
+  curve, stats).
+- ``sim_broker`` — port of ``algo/SimBroker.js`` (next-open market fills,
+  limit/stop rules, OCO brackets with stop-first resolution).
+- ``backtester`` — port of ``algo/Backtester.js`` (one-bar-lag replay loop).
+- ``strategies`` — port of the core long/flat strategies + the base ``Strategy``.
+- ``param_form`` — Tk port of ``algo/ui/ParamForm.js`` (dynamic param inputs).
+- ``data`` — fetch T4 bars via ``chart.history.ChartHistory`` (or reuse the
+  chart window's already-loaded bars).
+- ``backtest_window`` — the Tk results viewer (mirrors ``algo/ui/BacktestPanel.js``).
+"""

--- a/tools/Python/PyDemo/backtest/backtest_window.py
+++ b/tools/Python/PyDemo/backtest/backtest_window.py
@@ -1,0 +1,464 @@
+"""backtest/backtest_window.py
+
+Tkinter results viewer for the single-instrument backtester — the Python
+counterpart of JSDemo's ``algo/ui/BacktestPanel.js``. It runs the SAME strategies
+on T4 bars (the chart's loaded history, or a fetched range) and shows:
+
+* an 8-cell stats grid (Net Profit / Return / Max Drawdown / Trades / Win Rate /
+  Profit Factor / Sharpe / Final Equity),
+* an equity curve,
+* a Strategy-View sub-chart (the active strategy's own plot lines + entry/exit
+  markers; an oscillator pane for RSI/MACD),
+* a trade blotter.
+
+The backtest runs on a worker thread (``backtester.Backtester`` is CPU-bound) and
+results are marshalled back onto the Tk thread via ``after()`` — tkinter is not
+thread-safe. Importing this module requires matplotlib; callers should guard the
+import (see t4_gui) so a missing dep disables the feature gracefully.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import math
+import queue
+import threading
+import tkinter as tk
+from tkinter import ttk
+
+from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
+from matplotlib.figure import Figure
+
+from . import data
+from .backtester import Backtester
+from .param_form import build_param_inputs, read_param_inputs
+from .strategies import REGISTRY
+
+# Interval label -> seconds. ChartHistory.interval_to_t4 derives the T4
+# (unit, period) for any of these.
+_INTERVALS = [("15s", 15), ("1m", 60), ("5m", 300), ("15m", 900),
+              ("1h", 3600), ("1d", 86400)]
+_LABEL_TO_SEC = dict(_INTERVALS)
+_SEC_TO_LABEL = {s: l for l, s in _INTERVALS}
+
+
+# --- formatting helpers ------------------------------------------------------
+def _fmt_money(v) -> str:
+    return "—" if v is None or (isinstance(v, float) and not math.isfinite(v)) else f"${float(v):,.2f}"
+
+
+def _fmt_pct(v) -> str:
+    return "—" if v is None or (isinstance(v, float) and not math.isfinite(v)) else f"{float(v):.2f}%"
+
+
+def _fmt_num(v) -> str:
+    if v is None:
+        return "—"
+    if isinstance(v, float) and math.isinf(v):
+        return "∞"
+    if isinstance(v, float) and math.isnan(v):
+        return "—"
+    return f"{float(v):.2f}"
+
+
+def _dtime(unix_sec) -> _dt.datetime:
+    return _dt.datetime.utcfromtimestamp(int(unix_sec))
+
+
+class BacktestWindow(tk.Toplevel):
+    def __init__(self, parent, client=None):
+        super().__init__(parent)
+        self.client = client
+        self.title("Backtester — single-instrument strategy")
+        self.geometry("860x860")
+        self.configure(bg="white")
+        self._running = False
+        self._param_widgets = {}
+        # Worker results are marshalled back to the Tk thread through this queue
+        # and drained by a main-thread poller; never touch tkinter from _worker
+        # (tkinter is not thread-safe — that includes after()).
+        self._result_q = queue.Queue()
+        self._build()
+
+    # -- UI construction -------------------------------------------------------
+    def _build(self):
+        form = tk.Frame(self, bg="white", padx=16, pady=10)
+        form.pack(fill="x")
+
+        # Strategy dropdown (display names -> registry keys).
+        self._name_to_key = {cls.DISPLAY_NAME: key for key, cls in REGISTRY.items()}
+        tk.Label(form, text="Strategy:", bg="white").grid(row=0, column=0, sticky="w")
+        self.strategy = ttk.Combobox(form, values=list(self._name_to_key.keys()),
+                                     state="readonly", width=20)
+        self.strategy.grid(row=0, column=1, columnspan=3, sticky="w", padx=(4, 16))
+        self.strategy.bind("<<ComboboxSelected>>", lambda _e: self._rebuild_params())
+
+        # Dynamic strategy params.
+        self.params_frame = tk.Frame(form, bg="white")
+        self.params_frame.grid(row=1, column=0, columnspan=4, sticky="w", pady=(6, 6))
+
+        # Cost model.
+        tk.Label(form, text="Point value:", bg="white").grid(row=2, column=0, sticky="w")
+        self.point_value = tk.Entry(form, width=8)
+        self.point_value.insert(0, "1")
+        self.point_value.grid(row=2, column=1, sticky="w", padx=(4, 16))
+        tk.Label(form, text="Commission:", bg="white").grid(row=2, column=2, sticky="w")
+        self.commission = tk.Entry(form, width=8)
+        self.commission.insert(0, "0")
+        self.commission.grid(row=2, column=3, sticky="w", padx=(4, 16))
+        tk.Label(form, text="Slippage:", bg="white").grid(row=2, column=4, sticky="w")
+        self.slippage = tk.Entry(form, width=8)
+        self.slippage.insert(0, "0")
+        self.slippage.grid(row=2, column=5, sticky="w", padx=(4, 16))
+
+        # Data window.
+        tk.Label(form, text="Interval:", bg="white").grid(row=3, column=0, sticky="w", pady=(6, 0))
+        self.interval = ttk.Combobox(form, values=[l for l, _ in _INTERVALS],
+                                     state="readonly", width=6)
+        self.interval.set("1m")
+        self.interval.grid(row=3, column=1, sticky="w", padx=(4, 16), pady=(6, 0))
+        tk.Label(form, text="From:", bg="white").grid(row=3, column=2, sticky="w", pady=(6, 0))
+        self.start = tk.Entry(form, width=18)
+        self.start.grid(row=3, column=3, sticky="w", padx=(4, 8), pady=(6, 0))
+        tk.Label(form, text="To:", bg="white").grid(row=3, column=4, sticky="w", pady=(6, 0))
+        self.end = tk.Entry(form, width=18)
+        self.end.grid(row=3, column=5, sticky="w", padx=(4, 8), pady=(6, 0))
+
+        self.run_btn = tk.Button(form, text="Run Backtest", bg="#3b82f6", fg="white",
+                                 command=self._run)
+        self.run_btn.grid(row=0, column=4, columnspan=2, sticky="e", padx=(8, 0))
+
+        self.status = tk.Label(self, text="", bg="white", fg="#555", anchor="w")
+        self.status.pack(fill="x", padx=16)
+        note = tk.Label(
+            self, bg="white", fg="#777", justify="left", anchor="w", wraplength=820,
+            text=("Runs the selected strategy on T4 bars. Leave From/To blank to "
+                  "backtest the chart window's currently-loaded bars; set them "
+                  "(YYYY-MM-DD or 'YYYY-MM-DD HH:MM') to fetch that range for the "
+                  "selected market (needs login + a subscribed contract)."),
+        )
+        note.pack(fill="x", padx=16, pady=(0, 6))
+
+        # Stats grid.
+        self.stats_frame = tk.Frame(self, bg="white", padx=16, pady=6)
+        self.stats_frame.pack(fill="x")
+
+        # Result tabs: Equity / Strategy View / Trades.
+        nb = ttk.Notebook(self)
+        nb.pack(fill="both", expand=True, padx=12, pady=(4, 10))
+
+        eq_tab = tk.Frame(nb, bg="white")
+        nb.add(eq_tab, text="Equity Curve")
+        self.eq_fig = Figure(figsize=(7.8, 3.2), dpi=100)
+        self.eq_ax = self.eq_fig.add_subplot(111)
+        self.eq_fig.tight_layout()
+        self.eq_canvas = FigureCanvasTkAgg(self.eq_fig, master=eq_tab)
+        self.eq_canvas.get_tk_widget().pack(fill="both", expand=True)
+
+        sv_tab = tk.Frame(nb, bg="white")
+        nb.add(sv_tab, text="Strategy View")
+        self.sv_fig = Figure(figsize=(7.8, 3.6), dpi=100)
+        self.sv_canvas = FigureCanvasTkAgg(self.sv_fig, master=sv_tab)
+        self.sv_canvas.get_tk_widget().pack(fill="both", expand=True)
+
+        tr_tab = tk.Frame(nb, bg="white")
+        nb.add(tr_tab, text="Trades")
+        cols = ("time", "dir", "qty", "entry", "exit", "pnl")
+        headers = ("Time", "Dir", "Qty", "Entry", "Exit", "Net P&L")
+        self.tree = ttk.Treeview(tr_tab, columns=cols, show="headings", height=10)
+        for c, h in zip(cols, headers):
+            self.tree.heading(c, text=h)
+            self.tree.column(c, width=130, anchor="center")
+        vsb = ttk.Scrollbar(tr_tab, orient="vertical", command=self.tree.yview)
+        self.tree.configure(yscrollcommand=vsb.set)
+        self.tree.pack(side="left", fill="both", expand=True)
+        vsb.pack(side="right", fill="y")
+        self.tree.tag_configure("win", foreground="#137333")
+        self.tree.tag_configure("loss", foreground="#c0392b")
+
+        # Default selection + initial param render.
+        first = next(iter(self._name_to_key), None)
+        if first:
+            self.strategy.set(first)
+            self._rebuild_params()
+
+    def _rebuild_params(self):
+        key = self._name_to_key.get(self.strategy.get())
+        cls = REGISTRY.get(key)
+        if cls is None:
+            return
+        self._active_schema = cls.PARAMS
+        self._param_widgets = build_param_inputs(self.params_frame, cls.PARAMS)
+
+    # -- run / worker ----------------------------------------------------------
+    def _run(self):
+        if self._running:
+            return
+        key = self._name_to_key.get(self.strategy.get())
+        cls = REGISTRY.get(key)
+        if cls is None:
+            self._set_status("Pick a strategy.", error=True)
+            return
+        try:
+            cfg = {
+                "point_value": float(self.point_value.get() or 1),
+                "commission": float(self.commission.get() or 0),
+                "slippage": float(self.slippage.get() or 0),
+                "starting_cash": 100000,   # JSDemo parity
+            }
+        except ValueError:
+            self._set_status("Point value / commission / slippage must be numbers.", error=True)
+            return
+
+        start_raw = self.start.get().strip()
+        end_raw = self.end.get().strip()
+        use_fetch = bool(start_raw)
+        start_iso = end_iso = None
+        if use_fetch:
+            try:
+                start_iso = self._parse_dt(start_raw, end=False)
+                end_iso = self._parse_dt(end_raw, end=True) if end_raw else \
+                    _dt.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S")
+            except ValueError:
+                self._set_status("Dates must be 'YYYY-MM-DD' or 'YYYY-MM-DD HH:MM'.", error=True)
+                return
+
+        params = read_param_inputs(self._param_widgets, cls.PARAMS)
+        interval_sec = _LABEL_TO_SEC.get(self.interval.get(), 60)
+        opts = {
+            "cls": cls, "params": params, "cfg": cfg,
+            "use_fetch": use_fetch, "interval_sec": interval_sec,
+            "start_iso": start_iso, "end_iso": end_iso,
+        }
+        self._running = True
+        self.run_btn.config(state="disabled")
+        self._set_status("Running…")
+        threading.Thread(target=self._worker, args=(opts,), daemon=True).start()
+        # Poll from the main (Tk) thread — after() is only safe to call here.
+        self._poll_results()
+
+    def _worker(self, opts):
+        # Runs off the Tk thread: must not call any tkinter method (including
+        # after()). Push the outcome onto the queue; the poller does the UI work.
+        try:
+            tz = self._tz_offset()
+            if opts["use_fetch"]:
+                bars, source = data.fetch_t4_bars(
+                    self.client, opts["interval_sec"], opts["start_iso"], opts["end_iso"], tz)
+                interval_sec = opts["interval_sec"]
+                src_label = f"fetched ({source})"
+            else:
+                bars, interval_sec = data.chart_bars(self.client)
+                src_label = "chart history"
+            strategy = opts["cls"](opts["params"])
+            result = Backtester().run(bars, strategy, opts["cfg"],
+                                      interval_ms=interval_sec * 1000)
+            result["_meta"] = {
+                "rows": len(bars), "interval_sec": interval_sec, "source": src_label,
+                "span": f"{_dtime(bars[0]['time']):%Y-%m-%d %H:%M} → "
+                        f"{_dtime(bars[-1]['time']):%Y-%m-%d %H:%M}",
+                "plots_schema": opts["cls"].PLOTS,
+            }
+        except data.BacktestDataError as exc:
+            self._result_q.put(("error", str(exc)))
+            return
+        except Exception as exc:  # noqa: BLE001 - never let the worker die silently
+            self._result_q.put(("error", f"Unexpected error: {exc}"))
+            return
+        self._result_q.put(("render", result))
+
+    def _poll_results(self):
+        """Drain worker results on the Tk thread; reschedule until one arrives."""
+        try:
+            kind, payload = self._result_q.get_nowait()
+        except queue.Empty:
+            if self._running:
+                self.after(100, self._poll_results)
+            return
+        if kind == "error":
+            self._on_error(payload)
+        else:
+            self._render(payload)
+
+    def _on_error(self, msg):
+        self._running = False
+        self.run_btn.config(state="normal")
+        self._set_status(f"Failed: {msg}", error=True)
+
+    # -- rendering -------------------------------------------------------------
+    def _render(self, result):
+        self._running = False
+        self.run_btn.config(state="normal")
+        try:
+            self._render_stats(result["stats"])
+            self._render_equity(result["equity_curve"])
+            self._render_strategy_view(result)
+            self._render_trades(result["trades"])
+            m = result["_meta"]
+            self._set_status(f"Done — {self.strategy.get()} on {m['rows']} bars "
+                             f"({_SEC_TO_LABEL.get(m['interval_sec'], '')}, {m['source']}, {m['span']}).")
+        except Exception as exc:  # noqa: BLE001
+            self._set_status(f"Render failed: {exc}", error=True)
+
+    def _render_stats(self, s):
+        for w in self.stats_frame.winfo_children():
+            w.destroy()
+        dd = f"{_fmt_money(s.get('maxDrawdown'))} ({_fmt_pct(s.get('maxDrawdownPct'))})"
+        sharpe_label = "Sharpe (ann.)" if s.get("sharpeAnnualized") else "Sharpe"
+        cells = [
+            ("Net Profit", _fmt_money(s.get("netProfit"))),
+            ("Return", _fmt_pct(s.get("totalReturnPct"))),
+            ("Max Drawdown", dd),
+            ("Trades", str(s.get("numTrades", 0))),
+            ("Win Rate", _fmt_pct(s.get("winRatePct"))),
+            ("Profit Factor", _fmt_num(s.get("profitFactor"))),
+            (sharpe_label, _fmt_num(s.get("sharpe"))),
+            ("Final Equity", _fmt_money(s.get("finalEquity"))),
+        ]
+        for i, (label, value) in enumerate(cells):
+            col = i % 4
+            row = (i // 4) * 2
+            tk.Label(self.stats_frame, text=label, bg="white", fg="#777",
+                     font=("Arial", 9)).grid(row=row, column=col, sticky="w", padx=(0, 22))
+            tk.Label(self.stats_frame, text=value, bg="white",
+                     font=("Arial", 12, "bold")).grid(row=row + 1, column=col, sticky="w", padx=(0, 22))
+
+    def _render_equity(self, equity):
+        self.eq_ax.clear()
+        self.eq_ax.set_title("Equity Curve", fontsize=9)
+        xs = [_dtime(p["time"]) for p in equity]
+        ys = [p["value"] for p in equity]
+        if xs:
+            self.eq_ax.plot(xs, ys, color="#2962ff", linewidth=1.5)
+        self.eq_ax.grid(True, alpha=0.3)
+        self.eq_fig.autofmt_xdate()
+        self.eq_fig.tight_layout()
+        self.eq_canvas.draw()
+
+    def _render_strategy_view(self, result):
+        plots = result.get("plots", [])
+        schema = result["_meta"]["plots_schema"]
+        trades = result.get("trades", [])
+        self.sv_fig.clear()
+
+        has_osc = any(p.get("scale") == "osc" for p in schema)
+        if has_osc:
+            ax_price = self.sv_fig.add_subplot(2, 1, 1)
+            ax_osc = self.sv_fig.add_subplot(2, 1, 2, sharex=ax_price)
+        else:
+            ax_price = self.sv_fig.add_subplot(1, 1, 1)
+            ax_osc = None
+
+        # Context close line.
+        cx = [_dtime(p["time"]) for p in plots]
+        cy = [p["close"] for p in plots]
+        if cx:
+            ax_price.plot(cx, cy, color="#b0bec5", linewidth=1.0, label="close")
+
+        # Price-scale plot lines.
+        for spec in schema:
+            if spec.get("scale") != "price":
+                continue
+            xs, ys = self._plot_series(plots, spec["key"])
+            if xs:
+                ax_price.plot(xs, ys, color=spec.get("color", "#000"),
+                              linewidth=1.2, label=spec.get("label", spec["key"]))
+
+        # Entry/exit markers (buy fills green up, sell fills red down).
+        self._mark_trades(ax_price, trades)
+        ax_price.set_title("Strategy View", fontsize=9)
+        ax_price.grid(True, alpha=0.3)
+        ax_price.legend(loc="upper left", fontsize=7, ncol=3)
+
+        # Oscillator pane (RSI / MACD lines + histogram).
+        if ax_osc is not None:
+            for spec in schema:
+                if spec.get("scale") != "osc":
+                    continue
+                xs, ys = self._plot_series(plots, spec["key"])
+                if not xs:
+                    continue
+                if spec.get("type") == "histogram":
+                    ax_osc.vlines(xs, 0, ys, color=spec.get("color", "#90a4ae"),
+                                  linewidth=1.0, label=spec.get("label", spec["key"]))
+                else:
+                    ax_osc.plot(xs, ys, color=spec.get("color", "#000"),
+                                linewidth=1.0, label=spec.get("label", spec["key"]))
+            ax_osc.axhline(0, color="#cccccc", linewidth=0.8)
+            ax_osc.grid(True, alpha=0.3)
+            ax_osc.legend(loc="upper left", fontsize=7, ncol=3)
+
+        self.sv_fig.autofmt_xdate()
+        self.sv_fig.tight_layout()
+        self.sv_canvas.draw()
+
+    @staticmethod
+    def _plot_series(plots, key):
+        xs, ys = [], []
+        for p in plots:
+            v = p.get("values", {}).get(key)
+            if v is not None:
+                xs.append(_dtime(p["time"]))
+                ys.append(v)
+        return xs, ys
+
+    @staticmethod
+    def _mark_trades(ax, trades):
+        buys_x, buys_y, sells_x, sells_y = [], [], [], []
+        for t in trades:
+            x = _dtime(t["time"])
+            if t["side"] > 0:
+                buys_x.append(x); buys_y.append(t["price"])
+            else:
+                sells_x.append(x); sells_y.append(t["price"])
+        if buys_x:
+            ax.scatter(buys_x, buys_y, marker="^", color="#26a69a", s=36, zorder=5, label="buy")
+        if sells_x:
+            ax.scatter(sells_x, sells_y, marker="v", color="#ef5350", s=36, zorder=5, label="sell")
+
+    def _render_trades(self, trades):
+        self.tree.delete(*self.tree.get_children())
+        closed = [t for t in trades if t.get("closing")]
+        if not closed:
+            self.tree.insert("", "end", values=("No closed trades", "", "", "", "", ""))
+            return
+        # Newest first, cap 200 (JSDemo parity).
+        for t in reversed(closed[-200:]):
+            net = (t.get("pnl") or 0) - (t.get("commission") or 0)
+            # The closing fill's side tells us the direction of the position it
+            # closed: a sell (-1) closed a long; a buy (+1) closed a short.
+            direction = "Long" if t["side"] < 0 else "Short"
+            tag = "win" if net > 0 else ("loss" if net < 0 else "")
+            self.tree.insert("", "end", tags=(tag,), values=(
+                f"{_dtime(t['time']):%Y-%m-%d %H:%M}",
+                direction,
+                int(t.get("closed_qty") or t.get("qty") or 0),
+                _fmt_num(t.get("entry_price")),
+                _fmt_num(t.get("price")),
+                _fmt_money(net),
+            ))
+
+    # -- helpers ---------------------------------------------------------------
+    def _tz_offset(self) -> float:
+        try:
+            cfg = (getattr(self.client, "config", None) or {}).get("chart", {}) or {}
+            return float(cfg.get("tz_offset_hours", 0.0) or 0.0)
+        except Exception:  # noqa: BLE001
+            return 0.0
+
+    @staticmethod
+    def _parse_dt(raw: str, end: bool) -> str:
+        """Parse 'YYYY-MM-DD' or 'YYYY-MM-DD HH:MM' to a T4 ISO string."""
+        raw = raw.strip().replace("T", " ")
+        for fmt in ("%Y-%m-%d %H:%M:%S", "%Y-%m-%d %H:%M", "%Y-%m-%d"):
+            try:
+                dt = _dt.datetime.strptime(raw, fmt)
+                if fmt == "%Y-%m-%d" and end:
+                    dt = dt.replace(hour=23, minute=59, second=59)
+                return dt.strftime("%Y-%m-%dT%H:%M:%S")
+            except ValueError:
+                continue
+        raise ValueError(f"unrecognized date: {raw!r}")
+
+    def _set_status(self, text, error=False):
+        self.status.config(text=text, fg="#c0392b" if error else "#555")

--- a/tools/Python/PyDemo/backtest/backtester.py
+++ b/tools/Python/PyDemo/backtest/backtester.py
@@ -1,0 +1,86 @@
+"""backtest/backtester.py
+
+Drives a strategy over a fixed list of historical bars through a SimBroker and
+returns the run's equity curve, trade blotter, summary stats, and per-bar plot
+values. A faithful port of ``algo/Backtester.js``.
+
+It is deliberately PURE: it takes already-normalized bars (display-unit OHLC,
+UTC-second timestamps, ascending) rather than fetching/parsing them — the UI
+sources those bars from the chart's loaded history or a T4 range fetch, so the
+backtest and the on-screen chart agree.
+"""
+
+from __future__ import annotations
+
+from .sim_broker import SimBroker
+
+
+class Backtester:
+    def run(self, bars, strategy, config=None, interval_ms=None) -> dict:
+        """Replay ``bars`` through ``strategy`` and return the result dict:
+        ``{bars, equity_curve, trades, stats, config, plots}``.
+
+        config keys: point_value, commission, slippage, starting_cash, log.
+        ``interval_ms`` (optional) annualizes Sharpe.
+        """
+        config = config or {}
+        if not isinstance(bars, list) or len(bars) < 2:
+            raise ValueError("Backtest needs at least 2 bars — load more history first")
+        # Defensive: ensure ascending by time (chart history already is).
+        series = sorted(bars, key=lambda b: b["time"])
+
+        sim = SimBroker(config)
+        log = config.get("log") if callable(config.get("log")) else (lambda *a, **k: None)
+        strategy.init(sim, {"log": log})
+
+        # Wire the strategy to the broker's bar/fill stream — the same hookup
+        # AlgoRunner does live. (No 'tick' in backtest: the engine is bar-driven.)
+        def _on_bar(b):
+            try:
+                strategy.on_bar(b)
+            except Exception as e:  # noqa: BLE001
+                log(f"Strategy error: {e}", "error")
+
+        def _on_fill(f):
+            try:
+                strategy.on_fill(f)
+            except Exception as e:  # noqa: BLE001
+                log(f"Strategy error: {e}", "error")
+
+        sim.on_bar = _on_bar
+        sim.on_fill = _on_fill
+
+        # No warmup seeding: the strategy accumulates indicators from the first
+        # bar, mirroring a live run that starts cold. process_bar synchronously
+        # invokes on_bar -> strategy.on_bar, so by the time it returns the
+        # strategy has stashed this bar's plot values; drain them per bar for the
+        # Strategy View.
+        plots = []
+        wants_plots = hasattr(strategy, "_drain_plots")
+        for b in series:
+            sim.process_bar(b)
+            if wants_plots:
+                plots.append({"time": b["time"], "close": b["close"],
+                              "values": strategy._drain_plots(),
+                              "net": sim.position()["net"]})
+
+        # Realize any open position at the last close for a clean net-profit
+        # figure (otherwise the result hides open risk).
+        last = series[-1]
+        sim.force_close(last["close"], last["time"])
+
+        teardown = getattr(strategy, "teardown", None)
+        if callable(teardown):
+            try:
+                teardown()
+            except Exception:  # noqa: BLE001
+                pass
+
+        return {
+            "bars": series,
+            "equity_curve": sim.portfolio.equity_curve,
+            "trades": sim.portfolio.trades,
+            "stats": sim.portfolio.stats(interval_ms),
+            "config": sim.config_summary(),
+            "plots": plots,
+        }

--- a/tools/Python/PyDemo/backtest/data.py
+++ b/tools/Python/PyDemo/backtest/data.py
@@ -1,0 +1,109 @@
+"""backtest/data.py
+
+Bar sourcing for the Backtester — T4 JSON data only (no CSV/Yahoo). Mirrors
+JSDemo's two modes:
+
+- ``chart_bars(client)`` — reuse the chart window's already-loaded bars (what's
+  on screen), so the backtest and the chart agree exactly. Used when From/To are
+  blank.
+- ``fetch_t4_bars(...)`` — fetch a fresh range for the currently-selected market
+  via :class:`chart.history.ChartHistory` (binary-first, JSON fallback). Used
+  when From/To are set. BLOCKING (HTTP) — call from a worker thread.
+
+Both return engine-ready bars: ``{time: int UTC seconds, open, high, low, close,
+volume}`` ascending, which is what :class:`backtest.backtester.Backtester` wants.
+"""
+
+from __future__ import annotations
+
+from chart.history import ChartHistory
+
+
+class BacktestDataError(RuntimeError):
+    """Raised when bars can't be sourced (no login/market, empty, etc.)."""
+
+
+def _to_engine_bars(bars) -> list[dict]:
+    """Normalize ChartHistory bars (time as a UTC datetime) to engine bars
+    (time as int UTC seconds), ascending."""
+    out = []
+    for b in bars or []:
+        t = b.get("time")
+        if t is None:
+            continue
+        ts = int(t.timestamp()) if hasattr(t, "timestamp") else int(t)
+        try:
+            out.append({
+                "time": ts,
+                "open": float(b["open"]),
+                "high": float(b["high"]),
+                "low": float(b["low"]),
+                "close": float(b["close"]),
+                "volume": float(b.get("volume", 0) or 0),
+            })
+        except (KeyError, TypeError, ValueError):
+            continue
+    out.sort(key=lambda x: x["time"])
+    return out
+
+
+def chart_bars(client) -> tuple[list[dict], int]:
+    """Engine bars + interval(seconds) from the chart window's loaded history."""
+    cw = getattr(client, "chart_window", None)
+    if cw is None:
+        raise BacktestDataError(
+            "Chart window unavailable — enable the chart, or set From/To dates to "
+            "fetch a range instead.")
+    raw = getattr(cw, "_history_bars", None) or []
+    bars = _to_engine_bars(raw)
+    if len(bars) < 2:
+        raise BacktestDataError(
+            "The chart has no loaded bars yet — subscribe to a market in the chart "
+            "first, or set From/To dates to fetch a range.")
+    interval = int(getattr(cw, "_history_interval", 60) or 60)
+    return bars, interval
+
+
+def fetch_t4_bars(client, interval_seconds: int, start: str, end: str,
+                  tz_offset_hours: float = 0.0) -> tuple[list[dict], str]:
+    """Fetch a T4 bar range for the currently-selected market. BLOCKING.
+
+    Args mirror the chart's own history load. Raises BacktestDataError with an
+    actionable message when there's no token / market / data.
+    """
+    token = getattr(client, "jw_token", None)
+    if not token:
+        raise BacktestDataError(
+            "Connect/login to T4 first — fetching a date range needs a live token. "
+            "(Blank dates reuse the chart's loaded bars instead.)")
+    market_id = getattr(client, "current_market_id", None)
+    details = (getattr(client, "market_details", {}) or {}).get(market_id)
+    exchange_id = getattr(details, "exchange_id", None) or getattr(client, "md_exchange_id", None)
+    contract_id = getattr(details, "contract_id", None) or getattr(client, "md_contract_id", None)
+    if not (exchange_id and contract_id):
+        raise BacktestDataError(
+            "No market selected — subscribe to a contract before fetching a range.")
+
+    api = getattr(client, "apiUrl", None)
+    base_url = (api.rstrip("/") + "/chart") if api else None
+    hist = ChartHistory(token, base_url=base_url, tz_offset_hours=tz_offset_hours)
+    try:
+        bars, source = hist.fetch(
+            exchange_id=exchange_id,
+            contract_id=contract_id,
+            market_id=market_id,
+            interval_seconds=interval_seconds,
+            trade_date_start=start,
+            trade_date_end=end,
+            live_price=getattr(client, "chart_window", None)
+            and getattr(client.chart_window, "_last_price", None),
+        )
+    finally:
+        hist.close()
+
+    engine_bars = _to_engine_bars(bars)
+    if len(engine_bars) < 2:
+        raise BacktestDataError(
+            f"Only {len(engine_bars)} bars returned for that range/interval — widen "
+            "the dates or pick a smaller interval.")
+    return engine_bars, source

--- a/tools/Python/PyDemo/backtest/indicators.py
+++ b/tools/Python/PyDemo/backtest/indicators.py
@@ -1,0 +1,148 @@
+"""backtest/indicators.py
+
+Pure indicator math, a faithful port of JSDemo's ``algo/strategies/indicators.js``.
+
+Unlike ``chart/features/indicators.py`` (whole-array pandas series for chart
+overlays), these operate on a plain list buffer (a strategy's rolling
+``_closes`` / ``_highs`` / ``_lows``) and return a single scalar for the MOST
+RECENT point — the natural shape for a strategy deciding on each closed bar.
+
+Every function returns ``None`` when there isn't enough data, so callers can use
+a simple ``if x is None: return`` warm-up guard (matching the strategies).
+
+No chart/DOM dependency — trivially unit-testable, and the implementations match
+the JS ones value-for-value (notably the Pine-seeded MACD and Wilder RSI).
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Optional, Sequence
+
+
+def sma(values: Sequence[float], period: int) -> Optional[float]:
+    """Simple moving average of the last ``period`` values. None if too short."""
+    if period <= 0 or len(values) < period:
+        return None
+    return sum(values[len(values) - period:]) / period
+
+
+def ema(values: Sequence[float], period: int) -> Optional[float]:
+    """EMA over the whole buffer, seeded with the SMA of the first ``period``
+    values (standard practice). Returns the latest EMA. None if too short."""
+    if period <= 0 or len(values) < period:
+        return None
+    k = 2 / (period + 1)
+    seed = sum(values[:period]) / period
+    prev = seed
+    for i in range(period, len(values)):
+        prev = values[i] * k + prev * (1 - k)
+    return prev
+
+
+def rsi(values: Sequence[float], period: int) -> Optional[float]:
+    """Wilder's RSI over the last ``period`` deltas (needs period+1 values).
+    Uses a simple average of gains/losses over the window — stateless for a
+    buffer-based caller, matching the JS implementation. Returns 0..100 or None."""
+    if period <= 0 or len(values) < period + 1:
+        return None
+    gain = 0.0
+    loss = 0.0
+    for i in range(len(values) - period, len(values)):
+        diff = values[i] - values[i - 1]
+        if diff >= 0:
+            gain += diff
+        else:
+            loss -= diff
+    avg_gain = gain / period
+    avg_loss = loss / period
+    if avg_loss == 0:
+        return 100.0
+    rs = avg_gain / avg_loss
+    return 100 - (100 / (1 + rs))
+
+
+def stdev(values: Sequence[float], period: int) -> Optional[float]:
+    """Population standard deviation of the last ``period`` values. None if short."""
+    mean = sma(values, period)
+    if mean is None:
+        return None
+    sq = 0.0
+    for i in range(len(values) - period, len(values)):
+        d = values[i] - mean
+        sq += d * d
+    return math.sqrt(sq / period)
+
+
+def highest(values: Sequence[float], period: int) -> Optional[float]:
+    """Highest value over the last ``period``. None if too short."""
+    if period <= 0 or len(values) < period:
+        return None
+    return max(values[len(values) - period:])
+
+
+def lowest(values: Sequence[float], period: int) -> Optional[float]:
+    """Lowest value over the last ``period``. None if too short."""
+    if period <= 0 or len(values) < period:
+        return None
+    return min(values[len(values) - period:])
+
+
+def macd(values: Sequence[float], fast_period: int, slow_period: int,
+         signal_period: int) -> Optional[dict]:
+    """MACD matching TradingView Pine's ``ta.macd(src, fast, slow, signal)``:
+
+        macd_line = ta.ema(src, fast) - ta.ema(src, slow)
+        signal    = ta.ema(macd_line, signal)
+        hist      = macd_line - signal
+
+    Pine's ``ta.ema`` seeds with the FIRST source value (``ema := na(ema[1]) ?
+    src : alpha*src + (1-alpha)*ema[1]``) and is defined from the first bar — NOT
+    an SMA seed. Replicating that seeding gives bar-for-bar parity with the
+    chart. Returns ``{'macd', 'signal', 'hist'}`` for the latest point, or None
+    if there are fewer than 2 values."""
+    if len(values) < 2:
+        return None
+    if fast_period <= 0 or slow_period <= 0 or signal_period <= 0:
+        return None
+
+    k_fast = 2 / (fast_period + 1)
+    k_slow = 2 / (slow_period + 1)
+    k_sig = 2 / (signal_period + 1)
+
+    # Pine seeding: every EMA starts at the first available value.
+    fast = values[0]
+    slow = values[0]
+    macd_val = fast - slow   # 0 at the first bar
+    signal = macd_val        # signal EMA seeds with macd[0]
+
+    for i in range(1, len(values)):
+        fast = values[i] * k_fast + fast * (1 - k_fast)
+        slow = values[i] * k_slow + slow * (1 - k_slow)
+        macd_val = fast - slow
+        signal = macd_val * k_sig + signal * (1 - k_sig)
+    return {"macd": macd_val, "signal": signal, "hist": macd_val - signal}
+
+
+def atr(highs: Sequence[float], lows: Sequence[float], closes: Sequence[float],
+        period: int) -> Optional[float]:
+    """Average True Range over the last ``period`` bars. For each bar, the true
+    range is ``max(high-low, |high-prevClose|, |low-prevClose|)``; ATR is the
+    simple mean of the last ``period`` true ranges (matching this module's
+    simple-average convention — see ``rsi``). Takes aligned high/low/close
+    buffers (oldest-first); needs period+1 values so the oldest TR has a prior
+    close. None if too short or buffers are misaligned/non-finite."""
+    if period <= 0:
+        return None
+    n = min(len(highs), len(lows), len(closes))
+    if n < period + 1:
+        return None
+    total = 0.0
+    for i in range(n - period, n):
+        prev_close = closes[i - 1]
+        h = highs[i]
+        l = lows[i]
+        if not (math.isfinite(h) and math.isfinite(l) and math.isfinite(prev_close)):
+            return None
+        total += max(h - l, abs(h - prev_close), abs(l - prev_close))
+    return total / period

--- a/tools/Python/PyDemo/backtest/param_form.py
+++ b/tools/Python/PyDemo/backtest/param_form.py
@@ -1,0 +1,52 @@
+"""backtest/param_form.py
+
+Tk port of ``algo/ui/ParamForm.js`` — render a strategy's PARAMS schema into
+form inputs and read them back, so the Backtester window stays generic: a new
+strategy that declares its own params just works, no panel edits.
+
+``build_param_inputs`` returns a dict of ``{key: Entry}`` widgets packed into the
+given parent; ``read_param_inputs`` coerces them by declared type and clamps to
+min/max, falling back to the schema default when blank or unparseable.
+"""
+
+from __future__ import annotations
+
+import tkinter as tk
+from tkinter import ttk
+
+
+def build_param_inputs(parent, schema) -> dict:
+    """Create a labelled entry per schema item; return {key: Entry}. Clears the
+    parent first (safe to call on strategy re-select)."""
+    for w in parent.winfo_children():
+        w.destroy()
+    widgets = {}
+    for i, p in enumerate(schema or []):
+        row = i // 2
+        col = (i % 2) * 2
+        label = tk.Label(parent, text=f"{p['label']}:", bg="white")
+        label.grid(row=row, column=col, sticky="w", padx=(0, 4), pady=2)
+        ent = tk.Entry(parent, width=8)
+        ent.insert(0, str(p["default"]))
+        ent.grid(row=row, column=col + 1, sticky="w", padx=(0, 16), pady=2)
+        widgets[p["key"]] = ent
+    return widgets
+
+
+def read_param_inputs(widgets: dict, schema) -> dict:
+    """Read the inputs back into a params dict, coercing by declared type and
+    clamping to min/max; falls back to the schema default when blank/unparseable."""
+    out = {}
+    for p in (schema or []):
+        ent = widgets.get(p["key"])
+        raw = ent.get().strip() if ent is not None else ""
+        try:
+            v = int(raw) if p["type"] == "int" else float(raw)
+        except (TypeError, ValueError):
+            v = p["default"]
+        if p.get("min") is not None and v < p["min"]:
+            v = p["min"]
+        if p.get("max") is not None and v > p["max"]:
+            v = p["max"]
+        out[p["key"]] = v
+    return out

--- a/tools/Python/PyDemo/backtest/portfolio.py
+++ b/tools/Python/PyDemo/backtest/portfolio.py
@@ -1,0 +1,161 @@
+"""backtest/portfolio.py
+
+Position + PnL accounting for the backtester — a faithful port of
+``algo/Portfolio.js``. Tracks net position, average entry, realized PnL (net of
+commission), an equity curve sampled per bar, and a trade blotter. PnL is in
+money via ``point_value`` (the contract's $ per price point); leave it 1 for PnL
+in points.
+
+Sign convention: net > 0 = long, net < 0 = short. side is +1 (buy) / -1 (sell).
+"""
+
+from __future__ import annotations
+
+import math
+
+
+def _sign(x: float) -> int:
+    return (x > 0) - (x < 0)
+
+
+class Portfolio:
+    def __init__(self, point_value: float = 1, commission: float = 0,
+                 starting_cash: float = 100000) -> None:
+        self.point_value = point_value
+        self.commission = commission       # per contract, per fill
+        self.starting_cash = starting_cash
+
+        self.net = 0
+        self.avg_price = None
+        self.realized = 0.0                # includes commission costs
+        self.trades = []                   # {time, side, qty, price, pnl, commission, ...}
+        self.equity_curve = []             # {time, value}
+        self._last_close = None
+
+    def apply_fill(self, side: int, qty: float, price: float, time_sec) -> None:
+        """Apply an execution. Handles opening, adding, reducing, closing, and
+        flipping in one path."""
+        qty = abs(qty)
+        if not qty or not math.isfinite(price):
+            return
+        signed = qty if side >= 0 else -qty
+        pnl = 0.0
+        closed_qty = 0          # contracts this fill closed (0 for pure opens/adds)
+        entry_avg = None        # avg entry price of the closed contracts
+
+        if self.net == 0 or _sign(self.net) == _sign(signed):
+            # Opening or adding to the position -> recompute weighted avg.
+            abs_net = abs(self.net)
+            self.avg_price = (price if self.avg_price is None
+                              else (self.avg_price * abs_net + price * qty) / (abs_net + qty))
+            self.net += signed
+        else:
+            # Reducing, closing, or flipping.
+            closing = min(qty, abs(self.net))
+            entry_avg = self.avg_price      # capture entry BEFORE it's mutated
+            closed_qty = closing
+            pnl = (price - self.avg_price) * closing * _sign(self.net) * self.point_value
+            self.realized += pnl
+            remaining = qty - closing       # > 0 means we flipped sides
+            self.net += signed
+            if self.net == 0:
+                self.avg_price = None
+            elif remaining > 0:
+                self.avg_price = price      # new position at fill price
+            # partial reduce leaves avg_price unchanged
+
+        commission_cost = self.commission * qty
+        self.realized -= commission_cost
+        self.trades.append({
+            "time": time_sec,
+            "side": 1 if signed > 0 else -1,
+            "qty": qty,
+            "price": price,
+            "pnl": pnl,                 # gross realized from this fill (0 when opening/adding)
+            "commission": commission_cost,
+            # A "closing" fill reduced/closed a position, so it completes a trade.
+            # Identified by closed_qty (not pnl != 0) so scratch trades still count.
+            "closing": closed_qty > 0,
+            "closed_qty": closed_qty,
+            "entry_price": entry_avg,
+        })
+
+    def unrealized(self, price) -> float:
+        if self.net == 0 or self.avg_price is None or price is None or not math.isfinite(price):
+            return 0.0
+        return (price - self.avg_price) * self.net * self.point_value
+
+    def mark_equity(self, time_sec, price) -> None:
+        """Record equity (cash + realized + open MTM) at a bar close."""
+        self._last_close = price
+        value = self.starting_cash + self.realized + self.unrealized(price)
+        self.equity_curve.append({"time": time_sec, "value": value})
+
+    def force_close(self, price, time_sec) -> None:
+        """Force-close any open position at ``price`` (end of a run)."""
+        if self.net == 0:
+            return
+        self.apply_fill(-1 if self.net > 0 else 1, abs(self.net), price, time_sec)
+
+    def stats(self, interval_ms=None) -> dict:
+        """Summary statistics. ``interval_ms`` (optional) annualizes the Sharpe
+        ratio under an approximate continuous-trading assumption."""
+        eq = self.equity_curve
+        final_equity = eq[-1]["value"] if eq else self.starting_cash
+        net_profit = self.realized
+        total_return_pct = (net_profit / self.starting_cash * 100) if self.starting_cash else None
+
+        # Max drawdown (peak-to-trough on the equity curve).
+        peak = -math.inf
+        max_dd = 0.0
+        max_dd_pct = 0.0
+        for p in eq:
+            if p["value"] > peak:
+                peak = p["value"]
+            dd = peak - p["value"]
+            if dd > max_dd:
+                max_dd = dd
+                max_dd_pct = (dd / abs(peak) * 100) if peak else 0.0
+
+        # Closed trades = fills that reduced/closed a position (keyed on
+        # 'closing', not pnl != 0, so scratch trades still count).
+        closed = [t for t in self.trades if t["closing"]]
+        wins = [t for t in closed if t["pnl"] > 0]
+        losses = [t for t in closed if t["pnl"] < 0]
+        gross_win = sum(t["pnl"] for t in wins)
+        gross_loss = abs(sum(t["pnl"] for t in losses))
+
+        # Per-bar returns -> (approx annualized) Sharpe.
+        rets = []
+        for i in range(1, len(eq)):
+            prev = eq[i - 1]["value"]
+            if prev:
+                rets.append((eq[i]["value"] - prev) / abs(prev))
+        mean = sum(rets) / len(rets) if rets else 0.0
+        variance = sum((r - mean) ** 2 for r in rets) / len(rets) if rets else 0.0
+        std = math.sqrt(variance)
+        sharpe = (mean / std) if std else 0.0
+        if interval_ms and std:
+            bars_per_year = (365 * 24 * 3600 * 1000) / interval_ms
+            sharpe *= math.sqrt(bars_per_year)
+
+        if gross_loss:
+            profit_factor = gross_win / gross_loss
+        else:
+            profit_factor = math.inf if gross_win else None
+
+        return {
+            "finalEquity": final_equity,
+            "netProfit": net_profit,
+            "totalReturnPct": total_return_pct,
+            "maxDrawdown": max_dd,
+            "maxDrawdownPct": max_dd_pct,
+            "numFills": len(self.trades),
+            "numTrades": len(closed),
+            "wins": len(wins),
+            "losses": len(losses),
+            "winRatePct": (len(wins) / len(closed) * 100) if closed else None,
+            "profitFactor": profit_factor,
+            "sharpe": sharpe,
+            "sharpeAnnualized": bool(interval_ms),
+        }

--- a/tools/Python/PyDemo/backtest/sim_broker.py
+++ b/tools/Python/PyDemo/backtest/sim_broker.py
@@ -32,11 +32,11 @@ class SimBroker:
     def __init__(self, config: dict | None = None) -> None:
         config = config or {}
         self.config = config
-        self.slippage = config.get("slippage") or 0     # price units, adverse
+        self.slippage = float(config.get("slippage") or 0.0)     # price units, adverse
         self.portfolio = Portfolio(
-            point_value=config.get("point_value", 1),
-            commission=config.get("commission", 0),
-            starting_cash=config.get("starting_cash", 100000),
+            point_value=float(config.get("point_value", 1) or 1),
+            commission=float(config.get("commission", 0) or 0),
+            starting_cash=float(config.get("starting_cash", 100000) or 100000),
         )
 
         self._pending = []        # market orders awaiting next open

--- a/tools/Python/PyDemo/backtest/sim_broker.py
+++ b/tools/Python/PyDemo/backtest/sim_broker.py
@@ -1,0 +1,196 @@
+"""backtest/sim_broker.py
+
+In-memory matching engine for backtesting — a faithful port of
+``algo/SimBroker.js``. The Backtester drives it bar-by-bar via ``process_bar``;
+the strategy that runs against it is the same code shape that would run live.
+
+Fill model (documented assumptions — this is bar data, not a real book):
+  - MARKET orders fill at the NEXT bar's open +/- slippage. Acting on a closed
+    bar then filling next-open avoids look-ahead bias.
+  - LIMIT buy fills if bar.low <= price (sell: bar.high >= price); a gap through
+    the limit fills at the bar open (price improvement).
+  - STOP triggers when the bar trades through it, then fills as market at the
+    stop (or gap-open) +/- slippage (adverse).
+  - Bracket TP/SL become an OCO pair. If both could fill in one bar, the STOP is
+    resolved first (pessimistic).
+
+Orders placed during a bar's close are queued; they cannot fill on the bar that
+triggered them.
+
+Unlike the JS version (an EventEmitter), this uses plain ``on_bar`` / ``on_fill``
+callbacks set by the Backtester — same call order, no event machinery needed.
+"""
+
+from __future__ import annotations
+
+import math
+
+from .portfolio import Portfolio
+
+
+class SimBroker:
+    def __init__(self, config: dict | None = None) -> None:
+        config = config or {}
+        self.config = config
+        self.slippage = config.get("slippage") or 0     # price units, adverse
+        self.portfolio = Portfolio(
+            point_value=config.get("point_value", 1),
+            commission=config.get("commission", 0),
+            starting_cash=config.get("starting_cash", 100000),
+        )
+
+        self._pending = []        # market orders awaiting next open
+        self._resting = []        # limit/stop orders
+        self._seq = 0
+        self._clock_ms = 0
+
+        # Wired by the Backtester (mirrors AlgoRunner's live hookup).
+        self.on_bar = None        # callable(bar_dict)
+        self.on_fill = None       # callable(fill_dict)
+
+    # ---- order entry ---------------------------------------------------------
+    def buy(self, volume, opts=None):
+        return self._order(1, volume, opts or {})
+
+    def sell(self, volume, opts=None):
+        return self._order(-1, volume, opts or {})
+
+    def _order(self, side, volume, opts):
+        type_ = opts.get("type", "market")
+        price = opts.get("price")
+        tp = opts.get("tp")
+        sl = opts.get("sl")
+        try:
+            qty = max(1, int(volume))
+        except (TypeError, ValueError):
+            qty = 1
+        self._seq += 1
+        order_id = f"sim-{self._seq}"
+        bracket = {"tp": tp, "sl": sl} if (tp is not None or sl is not None) else None
+
+        if type_ == "market":
+            self._pending.append({"id": order_id, "side": side, "qty": qty, "bracket": bracket})
+        elif type_ in ("limit", "stop"):
+            if price is None or not math.isfinite(price):
+                raise ValueError(f"{type_} order requires a price")
+            self._resting.append({"id": order_id, "side": side, "qty": qty, "type": type_,
+                                  "price": price, "bracket": bracket, "oco_group": None})
+        else:
+            raise ValueError(f"Unknown order type: {type_}")
+        return order_id
+
+    def cancel(self, order_id) -> None:
+        self._resting = [o for o in self._resting if o["id"] != order_id]
+        self._pending = [o for o in self._pending if o["id"] != order_id]
+
+    def flatten(self) -> None:
+        """Cancel working orders, then market out of the net position."""
+        self._resting = []
+        net = self.portfolio.net
+        if net > 0:
+            self.sell(net, {"type": "market"})
+        elif net < 0:
+            self.buy(-net, {"type": "market"})
+
+    # ---- state ---------------------------------------------------------------
+    def position(self) -> dict:
+        return {"net": self.portfolio.net, "avg_price": self.portfolio.avg_price}
+
+    # ---- engine (called by Backtester) ---------------------------------------
+    def process_bar(self, bar: dict) -> None:
+        """Advance one bar: fill, mark equity, then deliver the close."""
+        self._clock_ms = bar["time"] * 1000
+        self._fill_pending_market(bar)
+        self._scan_resting(bar)
+        self.portfolio.mark_equity(bar["time"], bar["close"])
+        # Deliver the CLOSED bar; strategy may queue new orders for next bar.
+        if self.on_bar:
+            self.on_bar({
+                "time": bar["time"], "open": bar["open"], "high": bar["high"],
+                "low": bar["low"], "close": bar["close"], "volume": bar.get("volume", 0),
+            })
+
+    def force_close(self, price, time_sec) -> None:
+        """Close any open position at the final price (end of run)."""
+        self._pending = []
+        self._resting = []
+        self.portfolio.force_close(price, time_sec)
+
+    def config_summary(self) -> dict:
+        return {
+            "point_value": self.portfolio.point_value,
+            "commission": self.portfolio.commission,
+            "slippage": self.slippage,
+            "starting_cash": self.portfolio.starting_cash,
+        }
+
+    # ---- fill internals ------------------------------------------------------
+    def _emit_fill(self, order, price, bar) -> None:
+        self.portfolio.apply_fill(order["side"], order["qty"], price, bar["time"])
+        if self.on_fill:
+            self.on_fill({"order_id": order["id"], "side": order["side"],
+                          "volume": order["qty"], "price": price, "time": bar["time"]})
+
+    def _fill_pending_market(self, bar) -> None:
+        if not self._pending:
+            return
+        pending = self._pending
+        self._pending = []
+        for o in pending:
+            fill = bar["open"] + self.slippage if o["side"] > 0 else bar["open"] - self.slippage
+            self._emit_fill(o, fill, bar)
+            if o["bracket"]:
+                self._install_bracket(o, fill)
+
+    def _scan_resting(self, bar) -> None:
+        if not self._resting:
+            return
+        # Stops first so a one-bar TP+SL collision resolves pessimistically.
+        ordered = sorted(self._resting, key=lambda o: 0 if o["type"] == "stop" else 1)
+        filled_groups = set()
+        filled_ids = set()
+
+        for o in ordered:
+            if o["oco_group"] and o["oco_group"] in filled_groups:
+                continue  # sibling already filled
+            res = self._try_fill(o, bar)
+            if not res["filled"]:
+                continue
+            self._emit_fill(o, res["price"], bar)
+            filled_ids.add(o["id"])
+            if o["oco_group"]:
+                filled_groups.add(o["oco_group"])
+
+        # Drop filled orders and any OCO siblings whose partner filled.
+        self._resting = [o for o in self._resting
+                         if o["id"] not in filled_ids
+                         and not (o["oco_group"] and o["oco_group"] in filled_groups)]
+
+    def _try_fill(self, o, bar) -> dict:
+        if o["type"] == "limit":
+            if o["side"] > 0 and bar["low"] <= o["price"]:
+                return {"filled": True, "price": bar["open"] if bar["open"] <= o["price"] else o["price"]}
+            if o["side"] < 0 and bar["high"] >= o["price"]:
+                return {"filled": True, "price": bar["open"] if bar["open"] >= o["price"] else o["price"]}
+        elif o["type"] == "stop":
+            if o["side"] > 0 and bar["high"] >= o["price"]:
+                return {"filled": True, "price": max(o["price"], bar["open"]) + self.slippage}
+            if o["side"] < 0 and bar["low"] <= o["price"]:
+                return {"filled": True, "price": min(o["price"], bar["open"]) - self.slippage}
+        return {"filled": False}
+
+    def _install_bracket(self, parent, entry_price) -> None:
+        """Attach OCO TP/SL children once the parent (bracketed) order fills."""
+        self._seq += 1
+        group = f"oco-{self._seq}"
+        child_side = -1 if parent["side"] > 0 else 1   # exit is opposite the entry
+        tp = parent["bracket"]["tp"]
+        sl = parent["bracket"]["sl"]
+        if tp is not None:
+            self._seq += 1
+            self._resting.append({"id": f"sim-{self._seq}", "side": child_side, "qty": parent["qty"],
+                                  "type": "limit", "price": tp, "bracket": None, "oco_group": group})
+        if sl is not None:
+            self._seq += 1
+            self._resting.append({"id": f"sim-{self._seq}", "side": child_side, "qty": parent["qty"],
+                                  "type": "stop", "price": sl, "bracket": None, "oco_group": group})

--- a/tools/Python/PyDemo/backtest/sim_broker.py
+++ b/tools/Python/PyDemo/backtest/sim_broker.py
@@ -71,10 +71,14 @@ class SimBroker:
         if type_ == "market":
             self._pending.append({"id": order_id, "side": side, "qty": qty, "bracket": bracket})
         elif type_ in ("limit", "stop"):
-            if price is None or not math.isfinite(price):
-                raise ValueError(f"{type_} order requires a price")
+            try:
+                price_f = float(price)
+            except (TypeError, ValueError):
+                raise ValueError(f"{type_} order requires a numeric price") from None
+            if not math.isfinite(price_f):
+                raise ValueError(f"{type_} order requires a finite price")
             self._resting.append({"id": order_id, "side": side, "qty": qty, "type": type_,
-                                  "price": price, "bracket": bracket, "oco_group": None})
+                                  "price": price_f, "bracket": bracket, "oco_group": None})
         else:
             raise ValueError(f"Unknown order type: {type_}")
         return order_id

--- a/tools/Python/PyDemo/backtest/strategies/__init__.py
+++ b/tools/Python/PyDemo/backtest/strategies/__init__.py
@@ -1,0 +1,27 @@
+"""backtest/strategies — the core long/flat strategy library (JSDemo parity).
+
+``REGISTRY`` is an ordered mapping of class-name -> Strategy subclass so the
+Backtester window can populate its dropdown and instantiate by name, the same
+way JSDemo iterates ``Algo.strategies``. DonchianBreakout and the two-sided
+MomentumScalper are deferred to a follow-up.
+"""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+
+from .base import Strategy
+from .sma_crossover import SmaCrossover
+from .macd_cross import MacdCross
+from .rsi_reversion import RsiReversion
+from .bollinger_reversion import BollingerReversion
+
+REGISTRY = OrderedDict([
+    ("SmaCrossover", SmaCrossover),
+    ("MacdCross", MacdCross),
+    ("RsiReversion", RsiReversion),
+    ("BollingerReversion", BollingerReversion),
+])
+
+__all__ = ["Strategy", "REGISTRY", "SmaCrossover", "MacdCross",
+           "RsiReversion", "BollingerReversion"]

--- a/tools/Python/PyDemo/backtest/strategies/base.py
+++ b/tools/Python/PyDemo/backtest/strategies/base.py
@@ -1,0 +1,88 @@
+"""backtest/strategies/base.py
+
+Base class for backtest strategies — a port of ``algo/strategies/Strategy.js``.
+
+A strategy is pure decision logic: it reacts to closed bars and issues intents
+through the broker. It must not know whether the broker is live or simulated.
+
+Lifecycle (driven by the Backtester):
+    init(broker, ctx)  once, before any events
+    warmup(bars)       optional; seed indicators from history (no orders)
+    on_bar(bar)        on each CLOSED bar (primary entry point)
+    on_fill(fill)      on each execution (optional)
+    teardown()         once, on stop (optional)
+
+Subclasses declare ``PARAMS`` and ``PLOTS`` schemas (mirroring JSDemo's static
+``params`` / ``plots``) and override the event hooks. The buy/sell/flatten
+helpers forward to the broker so strategy code stays terse.
+"""
+
+from __future__ import annotations
+
+import math
+
+
+class Strategy:
+    DISPLAY_NAME = "Strategy"
+
+    # Tunable parameters, used by the UI to render inputs dynamically. Each item:
+    #   {key, label, type:'int'|'float', default, min?, max?, step?, title?}
+    PARAMS: list[dict] = []
+
+    # Traces the strategy draws on the Strategy View. Each item:
+    #   {key, label, type:'line'|'histogram', color, scale:'price'|'osc'}
+    PLOTS: list[dict] = []
+
+    def __init__(self, params: dict | None = None) -> None:
+        self.params = params or {}
+        self.broker = None
+        self._log = lambda *a, **k: None
+        # Per-bar scratch for the Strategy View: indicator readings keyed by plot
+        # key. Filled by plot() during on_bar, drained after on_bar.
+        self._plot = {}
+
+    # ---- lifecycle (override as needed) -------------------------------------
+    def init(self, broker, ctx=None) -> None:
+        ctx = ctx or {}
+        self.broker = broker
+        if callable(ctx.get("log")):
+            self._log = ctx["log"]
+
+    def warmup(self, bars) -> None:  # pragma: no cover - not used in backtest
+        pass
+
+    def on_bar(self, bar) -> None:
+        pass
+
+    def on_fill(self, fill) -> None:
+        pass
+
+    def teardown(self) -> None:
+        pass
+
+    # ---- helpers ------------------------------------------------------------
+    def buy(self, volume, opts=None):
+        return self.broker.buy(volume, opts or {})
+
+    def sell(self, volume, opts=None):
+        return self.broker.sell(volume, opts or {})
+
+    def flatten(self):
+        return self.broker.flatten()
+
+    def position(self):
+        return self.broker.position()
+
+    def log(self, msg, level="info"):
+        self._log(msg, level)
+
+    def plot(self, key, value) -> None:
+        """Record an indicator value for this bar so the Strategy View can plot
+        it. Only keys declared in PLOTS are rendered; others are harmless."""
+        if value is not None and math.isfinite(value):
+            self._plot[key] = value
+
+    def _drain_plots(self) -> dict:
+        p = self._plot
+        self._plot = {}
+        return p

--- a/tools/Python/PyDemo/backtest/strategies/bollinger_reversion.py
+++ b/tools/Python/PyDemo/backtest/strategies/bollinger_reversion.py
@@ -1,0 +1,86 @@
+"""backtest/strategies/bollinger_reversion.py
+
+Mean-reversion on Bollinger Bands, long/flat only — a port of
+``BollingerReversion.js``:
+  close crosses BELOW the lower band  -> go long (market buy qty)
+  close returns to/above the mid band -> go flat (flatten)
+
+Bands = SMA(period) +/- mult * stdev(period).
+"""
+
+from __future__ import annotations
+
+import math
+
+from .base import Strategy
+from .. import indicators as I
+
+
+def _int(v, default):
+    try:
+        return int(v)
+    except (TypeError, ValueError):
+        return default
+
+
+def _float_pos(v, default):
+    try:
+        f = float(v)
+        return f if (math.isfinite(f) and f > 0) else default
+    except (TypeError, ValueError):
+        return default
+
+
+class BollingerReversion(Strategy):
+    DISPLAY_NAME = "Bollinger Reversion"
+    PARAMS = [
+        {"key": "period", "label": "Period", "type": "int", "default": 20, "min": 2, "title": "SMA / band lookback"},
+        {"key": "mult", "label": "Std Mult", "type": "float", "default": 2.0, "min": 0.1, "step": "any", "title": "Band width in standard deviations"},
+        {"key": "qty", "label": "Qty", "type": "int", "default": 1, "min": 1, "title": "Contracts per entry"},
+    ]
+    PLOTS = [
+        {"key": "upper", "label": "Upper Band", "type": "line", "color": "#ef5350", "scale": "price"},
+        {"key": "mid", "label": "Mid (SMA)", "type": "line", "color": "#7e57c2", "scale": "price"},
+        {"key": "lower", "label": "Lower Band", "type": "line", "color": "#26a69a", "scale": "price"},
+    ]
+
+    def __init__(self, params=None):
+        super().__init__(params)
+        p = self.params
+        self.period = max(2, _int(p.get("period"), 20))
+        self.mult = _float_pos(p.get("mult"), 2.0)
+        self.qty = max(1, _int(p.get("qty"), 1))
+        self._closes = []
+
+    def init(self, broker, ctx=None):
+        super().init(broker, ctx)
+        self.log(f"Bollinger Reversion armed: period={self.period} mult={self.mult} qty={self.qty}")
+
+    def _push(self, close):
+        if close is None or not math.isfinite(close):
+            return
+        self._closes.append(close)
+        if len(self._closes) > self.period + 2:
+            self._closes.pop(0)
+
+    def on_bar(self, bar):
+        self._push(bar["close"])
+        mid = I.sma(self._closes, self.period)
+        sd = I.stdev(self._closes, self.period)
+        if mid is None or sd is None:
+            return  # warming up
+
+        lower = mid - self.mult * sd
+        self.plot("upper", mid + self.mult * sd)
+        self.plot("mid", mid)
+        self.plot("lower", lower)
+        net = self.position()["net"]
+
+        if bar["close"] < lower and net <= 0:
+            if net < 0:
+                self.flatten()
+            self.buy(self.qty, {"type": "market"})
+            self.log(f"Close {bar['close']} < lower {lower:.4f} -> BUY {self.qty}")
+        elif bar["close"] >= mid and net > 0:
+            self.flatten()
+            self.log(f"Close {bar['close']} >= mid {mid:.4f} -> FLATTEN")

--- a/tools/Python/PyDemo/backtest/strategies/macd_cross.py
+++ b/tools/Python/PyDemo/backtest/strategies/macd_cross.py
@@ -1,0 +1,84 @@
+"""backtest/strategies/macd_cross.py
+
+Trend/momentum via MACD, long/flat only — a port of ``MacdCross.js``. Uses
+``indicators.macd`` (Pine-seeded, matching TradingView ta.macd) so crossovers
+line up with the chart:
+  MACD line crosses ABOVE its signal (hist crosses 0 up)   -> go long
+  MACD line crosses BELOW its signal (hist crosses 0 down)  -> go flat
+"""
+
+from __future__ import annotations
+
+import math
+
+from .base import Strategy
+from .. import indicators as I
+
+
+def _int(v, default):
+    try:
+        return int(v)
+    except (TypeError, ValueError):
+        return default
+
+
+class MacdCross(Strategy):
+    DISPLAY_NAME = "MACD Crossover"
+    PARAMS = [
+        {"key": "fast", "label": "Fast", "type": "int", "default": 12, "min": 1, "title": "Fast EMA period"},
+        {"key": "slow", "label": "Slow", "type": "int", "default": 26, "min": 2, "title": "Slow EMA period"},
+        {"key": "signal", "label": "Signal", "type": "int", "default": 9, "min": 1, "title": "Signal EMA period"},
+        {"key": "qty", "label": "Qty", "type": "int", "default": 1, "min": 1, "title": "Contracts per entry"},
+    ]
+    PLOTS = [
+        {"key": "hist", "label": "Histogram", "type": "histogram", "color": "#90a4ae", "scale": "osc"},
+        {"key": "macd", "label": "MACD", "type": "line", "color": "#2962ff", "scale": "osc"},
+        {"key": "signal", "label": "Signal", "type": "line", "color": "#ff6d00", "scale": "osc"},
+    ]
+
+    def __init__(self, params=None):
+        super().__init__(params)
+        p = self.params
+        self.fast = max(1, _int(p.get("fast"), 12))
+        self.slow = max(self.fast + 1, _int(p.get("slow"), 26))
+        self.signal = max(1, _int(p.get("signal"), 9))
+        self.qty = max(1, _int(p.get("qty"), 1))
+        self._closes = []
+        # Generous buffer so the seeded EMAs converge to stable values.
+        self._cap = self.slow + self.signal + 250
+        self._prev_hist = None
+
+    def init(self, broker, ctx=None):
+        super().init(broker, ctx)
+        self.log(f"MACD Crossover armed: fast={self.fast} slow={self.slow} "
+                 f"signal={self.signal} qty={self.qty}")
+
+    def _push(self, close):
+        if close is None or not math.isfinite(close):
+            return
+        self._closes.append(close)
+        if len(self._closes) > self._cap:
+            self._closes.pop(0)
+
+    def on_bar(self, bar):
+        self._push(bar["close"])
+        m = I.macd(self._closes, self.fast, self.slow, self.signal)
+        if m is None:
+            return  # warming up
+        self.plot("macd", m["macd"])
+        self.plot("signal", m["signal"])
+        self.plot("hist", m["hist"])
+
+        if self._prev_hist is not None:
+            net = self.position()["net"]
+            crossed_up = self._prev_hist <= 0 and m["hist"] > 0
+            crossed_down = self._prev_hist >= 0 and m["hist"] < 0
+            if crossed_up and net <= 0:
+                if net < 0:
+                    self.flatten()
+                self.buy(self.qty, {"type": "market"})
+                self.log(f"MACD cross UP @ {bar['close']} -> BUY {self.qty}")
+            elif crossed_down and net > 0:
+                self.flatten()
+                self.log(f"MACD cross DOWN @ {bar['close']} -> FLATTEN")
+        self._prev_hist = m["hist"]

--- a/tools/Python/PyDemo/backtest/strategies/rsi_reversion.py
+++ b/tools/Python/PyDemo/backtest/strategies/rsi_reversion.py
@@ -1,0 +1,84 @@
+"""backtest/strategies/rsi_reversion.py
+
+Mean-reversion on Wilder's RSI, long/flat only — a port of ``RsiReversion.js``:
+  RSI crosses DOWN through `oversold` -> go long (market buy qty)
+  RSI crosses UP through `exit`       -> go flat (flatten)
+"""
+
+from __future__ import annotations
+
+import math
+
+from .base import Strategy
+from .. import indicators as I
+
+
+def _int(v, default):
+    try:
+        return int(v)
+    except (TypeError, ValueError):
+        return default
+
+
+def _float(v, default):
+    try:
+        f = float(v)
+        return f if math.isfinite(f) else default
+    except (TypeError, ValueError):
+        return default
+
+
+class RsiReversion(Strategy):
+    DISPLAY_NAME = "RSI Reversion"
+    PARAMS = [
+        {"key": "period", "label": "RSI Period", "type": "int", "default": 14, "min": 2, "title": "RSI lookback"},
+        {"key": "oversold", "label": "Oversold", "type": "float", "default": 30, "min": 1, "max": 99, "step": "any", "title": "Enter long when RSI dips below this"},
+        {"key": "exit", "label": "Exit", "type": "float", "default": 50, "min": 1, "max": 99, "step": "any", "title": "Flatten when RSI rises above this"},
+        {"key": "qty", "label": "Qty", "type": "int", "default": 1, "min": 1, "title": "Contracts per entry"},
+    ]
+    PLOTS = [
+        {"key": "rsi", "label": "RSI", "type": "line", "color": "#42a5f5", "scale": "osc"},
+    ]
+
+    def __init__(self, params=None):
+        super().__init__(params)
+        p = self.params
+        self.period = max(2, _int(p.get("period"), 14))
+        self.oversold = _float(p.get("oversold"), 30)
+        self.exit = _float(p.get("exit"), 50)
+        self.qty = max(1, _int(p.get("qty"), 1))
+        self._closes = []
+        self._prev_rsi = None
+
+    def init(self, broker, ctx=None):
+        super().init(broker, ctx)
+        self.log(f"RSI Reversion armed: period={self.period} oversold={self.oversold} "
+                 f"exit={self.exit} qty={self.qty}")
+
+    def _push(self, close):
+        if close is None or not math.isfinite(close):
+            return
+        self._closes.append(close)
+        if len(self._closes) > self.period + 2:    # need period+1; small margin
+            self._closes.pop(0)
+
+    def on_bar(self, bar):
+        self._push(bar["close"])
+        rsi_now = I.rsi(self._closes, self.period)
+        if rsi_now is None:
+            return  # warming up
+        self.plot("rsi", rsi_now)
+
+        if self._prev_rsi is not None:
+            net = self.position()["net"]
+            crossed_down_oversold = self._prev_rsi >= self.oversold and rsi_now < self.oversold
+            crossed_up_exit = self._prev_rsi <= self.exit and rsi_now > self.exit
+            if crossed_down_oversold and net <= 0:
+                if net < 0:
+                    self.flatten()
+                self.buy(self.qty, {"type": "market"})
+                self.log(f"RSI {rsi_now:.1f} < {self.oversold} @ {bar['close']} -> BUY {self.qty}")
+            elif crossed_up_exit and net > 0:
+                self.flatten()
+                self.log(f"RSI {rsi_now:.1f} > {self.exit} @ {bar['close']} -> FLATTEN")
+        self._prev_rsi = rsi_now

--- a/tools/Python/PyDemo/backtest/strategies/sma_crossover.py
+++ b/tools/Python/PyDemo/backtest/strategies/sma_crossover.py
@@ -1,0 +1,76 @@
+"""backtest/strategies/sma_crossover.py
+
+Moving-average crossover, long/flat only — a port of ``SmaCrossover.js``:
+  fast SMA crosses ABOVE slow SMA -> go long (market buy qty)
+  fast SMA crosses BELOW slow SMA -> go flat (flatten)
+
+Decides only on CLOSED bars (on_bar).
+"""
+
+from __future__ import annotations
+
+from .base import Strategy
+from .. import indicators as I
+
+
+def _int(v, default):
+    try:
+        return int(v)
+    except (TypeError, ValueError):
+        return default
+
+
+class SmaCrossover(Strategy):
+    DISPLAY_NAME = "SMA Crossover"
+    PARAMS = [
+        {"key": "fast", "label": "Fast", "type": "int", "default": 9, "min": 1, "title": "Fast SMA period"},
+        {"key": "slow", "label": "Slow", "type": "int", "default": 21, "min": 2, "title": "Slow SMA period"},
+        {"key": "qty", "label": "Qty", "type": "int", "default": 1, "min": 1, "title": "Contracts per entry"},
+    ]
+    PLOTS = [
+        {"key": "fast", "label": "Fast SMA", "type": "line", "color": "#f6a609", "scale": "price"},
+        {"key": "slow", "label": "Slow SMA", "type": "line", "color": "#7e57c2", "scale": "price"},
+    ]
+
+    def __init__(self, params=None):
+        super().__init__(params)
+        p = self.params
+        self.fast = max(1, _int(p.get("fast"), 9))
+        self.slow = max(self.fast + 1, _int(p.get("slow"), 21))
+        self.qty = max(1, _int(p.get("qty"), 1))
+        self._closes = []
+        self._prev_fast = None
+        self._prev_slow = None
+
+    def init(self, broker, ctx=None):
+        super().init(broker, ctx)
+        self.log(f"SMA Crossover armed: fast={self.fast} slow={self.slow} qty={self.qty}")
+
+    def on_bar(self, bar):
+        self._closes.append(bar["close"])
+        if len(self._closes) > self.slow + 2:    # bound memory
+            self._closes.pop(0)
+
+        fast_now = I.sma(self._closes, self.fast)
+        slow_now = I.sma(self._closes, self.slow)
+        if fast_now is None or slow_now is None:
+            return  # warming up
+
+        self.plot("fast", fast_now)
+        self.plot("slow", slow_now)
+
+        if self._prev_fast is not None and self._prev_slow is not None:
+            crossed_up = self._prev_fast <= self._prev_slow and fast_now > slow_now
+            crossed_down = self._prev_fast >= self._prev_slow and fast_now < slow_now
+            net = self.position()["net"]
+            if crossed_up and net <= 0:
+                if net < 0:
+                    self.flatten()
+                self.buy(self.qty, {"type": "market"})
+                self.log(f"Cross UP @ {bar['close']} -> BUY {self.qty}")
+            elif crossed_down and net > 0:
+                self.flatten()
+                self.log(f"Cross DOWN @ {bar['close']} -> FLATTEN")
+
+        self._prev_fast = fast_now
+        self._prev_slow = slow_now

--- a/tools/Python/PyDemo/chart/__init__.py
+++ b/tools/Python/PyDemo/chart/__init__.py
@@ -1,0 +1,9 @@
+"""Companion TradingView Lightweight Charts window for PyDemo.
+
+This package adds a live candlestick chart to the PyDemo trading client. It
+runs in its own pywebview window (the lightweight-charts library cannot be
+embedded inside a tkinter frame) and is bridged back to the tkinter/asyncio
+app via a thread-safe queue.
+
+Public entry point: :class:`chart.chart_window.ChartWindow`.
+"""

--- a/tools/Python/PyDemo/chart/_lwc_patches.py
+++ b/tools/Python/PyDemo/chart/_lwc_patches.py
@@ -1,0 +1,71 @@
+"""Runtime patches to the bundled ``lightweight-charts`` library.
+
+These run in the *parent* process (where the chart command strings are built),
+so unlike the webview message-pump loop they actually take effect.
+
+Currently one patch: make ``js_data`` emit COMPACT JSON. The stock implementation
+(`lightweight_charts/util.py`) serialises every ``setData`` payload with
+``json.dumps(..., indent=2)``. For a large/scroll-grown candle set that pretty-
+printing inflates the embedded script to multiple MB, which WebView2 renders only
+partially ("half-loaded" candles). Dropping the indent shrinks the payload ~40%
+and is what makes large initial loads and infinite scroll-back render reliably.
+
+``abstract.py`` does ``from .util import js_data``, so it holds its own name
+binding — we patch BOTH module attributes. Idempotent and defensive: a future
+library version that changes ``js_data`` simply isn't patched (no crash).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+import pandas as pd
+
+log = logging.getLogger("pydemo.chart.lwc_patches")
+
+_applied = False
+
+
+def _compact_js_data(data):
+    """Compact (no-indent) drop-in for ``lightweight_charts.util.js_data``.
+
+    Mirrors the stock record shaping (drop None/NaN cells for DataFrames; pass
+    Series through) but serialises without ``indent=2``.
+    """
+    if isinstance(data, pd.DataFrame):
+        records = data.to_dict(orient="records")
+        filtered = [
+            {k: v for k, v in record.items() if v is not None and not pd.isna(v)}
+            for record in records
+        ]
+    else:
+        filtered = dict(data.to_dict())
+    return json.dumps(filtered)
+
+
+def apply_patches() -> None:
+    """Install the compact-``js_data`` patch on every lightweight-charts module
+    that imported it. Safe to call more than once."""
+    global _applied
+    if _applied:
+        return
+    try:
+        from lightweight_charts import util as _util
+        patched_any = False
+        if hasattr(_util, "js_data"):
+            _util.js_data = _compact_js_data
+            patched_any = True
+        # abstract.py did `from .util import js_data`, so it has its own binding.
+        try:
+            from lightweight_charts import abstract as _abstract
+            if hasattr(_abstract, "js_data"):
+                _abstract.js_data = _compact_js_data
+                patched_any = True
+        except Exception:  # noqa: BLE001 - abstract layout may differ
+            pass
+        _applied = patched_any
+        if patched_any:
+            log.debug("chart: applied compact js_data patch")
+    except Exception:  # noqa: BLE001 - never let a patch failure break the chart
+        log.exception("chart: failed to apply lightweight-charts patches")

--- a/tools/Python/PyDemo/chart/aggregator.py
+++ b/tools/Python/PyDemo/chart/aggregator.py
@@ -1,0 +1,144 @@
+"""Live tick storage and time-bucketed candle aggregation.
+
+Port of the JS ``TickStore`` / ``CandleAggregator`` pair (JSDemo
+``ChartService.js``). Turns the live trade-tick stream PyDemo already receives
+into forming/closing OHLCV bars at a configurable interval.
+
+* :class:`TickStore` - bounded ring buffer of recent ticks per market.
+* :class:`CandleAggregator` - folds ticks into the current bar; on a bucket
+  rollover it leaves the finished bar in place and starts a new one.
+
+Times are handled as float UTC epoch seconds internally; emitted bars carry a
+timezone-aware ``datetime`` so they drop straight into a lightweight-charts
+``update`` call. The aggregator does **no** trade de-duplication - the caller
+de-dupes using the market's cumulative traded volume before calling
+:meth:`CandleAggregator.add_tick` (see ``chart_window``).
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from datetime import datetime, timezone
+from typing import Deque, Optional
+
+
+class TickStore:
+    """Bounded ring buffer of recent ticks, keyed by market id."""
+
+    def __init__(self, capacity: int = 5000) -> None:
+        self._capacity = capacity
+        self._by_market: dict[str, Deque[dict]] = {}
+
+    def push(self, market_id: str, tick: dict) -> None:
+        buf = self._by_market.get(market_id)
+        if buf is None:
+            buf = deque(maxlen=self._capacity)
+            self._by_market[market_id] = buf
+        buf.append(tick)
+
+    def get(self, market_id: str) -> list[dict]:
+        return list(self._by_market.get(market_id, ()))
+
+    def clear(self, market_id: Optional[str] = None) -> None:
+        if market_id is None:
+            self._by_market.clear()
+        else:
+            self._by_market.pop(market_id, None)
+
+
+class CandleAggregator:
+    """Aggregates ticks into OHLCV bars at a fixed interval."""
+
+    def __init__(self, interval_seconds: int = 60) -> None:
+        if interval_seconds <= 0:
+            raise ValueError("interval_seconds must be positive")
+        self._interval = int(interval_seconds)
+        self._bucket: Optional[int] = None  # epoch-second start of current bar
+        self._bar: Optional[dict] = None    # current forming bar (epoch-sec time)
+
+    @property
+    def interval_seconds(self) -> int:
+        return self._interval
+
+    def reset(self, interval_seconds: Optional[int] = None) -> None:
+        """Clear state, optionally switching interval (on interval change)."""
+        if interval_seconds is not None:
+            if interval_seconds <= 0:
+                raise ValueError("interval_seconds must be positive")
+            self._interval = int(interval_seconds)
+        self._bucket = None
+        self._bar = None
+
+    def _bucket_start(self, ts: float) -> int:
+        return int(ts // self._interval) * self._interval
+
+    def seed_last_bar(self, bar: dict) -> None:
+        """Continue live aggregation from the last historical bar.
+
+        ``bar`` is a chart bar dict (``time`` may be ``datetime`` or epoch
+        seconds). The next tick falling in the same bucket folds into it rather
+        than resetting the open.
+        """
+        ts = self._to_epoch(bar["time"])
+        self._bucket = self._bucket_start(ts)
+        self._bar = {
+            "_ts": self._bucket,
+            "open": float(bar["open"]),
+            "high": float(bar["high"]),
+            "low": float(bar["low"]),
+            "close": float(bar["close"]),
+            "volume": int(bar.get("volume", 0) or 0),
+        }
+
+    def add_tick(self, price: float, volume: int, ts: float) -> Optional[dict]:
+        """Fold one trade into the current bar and return the bar to render.
+
+        Returns a chart bar dict (``time`` as UTC ``datetime``) to pass to
+        ``chart.update``. Out-of-order ticks (older than the current bucket) are
+        ignored and return ``None``, mirroring the JS monotonic-stream
+        assumption.
+        """
+        bucket = self._bucket_start(ts)
+
+        if self._bar is None or bucket > self._bucket:
+            # First tick, or a new bucket: start a fresh bar.
+            self._bucket = bucket
+            self._bar = {
+                "_ts": bucket,
+                "open": price,
+                "high": price,
+                "low": price,
+                "close": price,
+                "volume": int(volume),
+            }
+        elif bucket < self._bucket:
+            # Out-of-order / late tick - ignore.
+            return None
+        else:
+            # Same bucket: update the forming bar.
+            bar = self._bar
+            bar["high"] = max(bar["high"], price)
+            bar["low"] = min(bar["low"], price)
+            bar["close"] = price
+            bar["volume"] += int(volume)
+
+        return self._render(self._bar)
+
+    @staticmethod
+    def _render(bar: dict) -> dict:
+        return {
+            "time": datetime.fromtimestamp(bar["_ts"], tz=timezone.utc),
+            "open": bar["open"],
+            "high": bar["high"],
+            "low": bar["low"],
+            "close": bar["close"],
+            "volume": bar["volume"],
+        }
+
+    @staticmethod
+    def _to_epoch(t) -> float:
+        if isinstance(t, datetime):
+            if t.tzinfo is None:
+                t = t.replace(tzinfo=timezone.utc)
+            return t.timestamp()
+        return float(t)

--- a/tools/Python/PyDemo/chart/bridge.py
+++ b/tools/Python/PyDemo/chart/bridge.py
@@ -1,0 +1,51 @@
+"""Thread-safe bridge between chart-window callbacks and the asyncio app.
+
+The lightweight-charts window runs in its own process; its Python-side event
+callbacks (interval switcher, clicks, range changes) are dispatched on the
+asyncio loop that runs ``show_async``. This is the same loop that drives
+PyDemo's tkinter update loop, so scheduling work back into the app is just a
+matter of launching coroutines safely and never letting a callback exception
+escape into the chart's event dispatcher.
+
+:class:`CallbackBridge` provides that: ``run_coro`` schedules a coroutine
+factory on the loop (thread-safe), and ``guard`` wraps a sync callback so
+exceptions are logged instead of killing the dispatcher.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import functools
+import logging
+from typing import Awaitable, Callable
+
+log = logging.getLogger("pydemo.chart.bridge")
+
+
+class CallbackBridge:
+    def __init__(self, loop: asyncio.AbstractEventLoop) -> None:
+        self._loop = loop
+
+    def run_coro(self, coro_factory: Callable[[], Awaitable]) -> None:
+        """Schedule ``coro_factory()`` on the app loop from any thread."""
+        def _launch() -> None:
+            try:
+                asyncio.ensure_future(coro_factory())
+            except Exception:  # noqa: BLE001
+                log.exception("chart callback failed to schedule coroutine")
+
+        try:
+            self._loop.call_soon_threadsafe(_launch)
+        except RuntimeError:
+            # Loop closed (app shutting down) - drop the callback.
+            log.debug("event loop unavailable; dropping chart callback")
+
+    def guard(self, fn: Callable) -> Callable:
+        """Wrap a sync callback so exceptions are logged, not raised."""
+        @functools.wraps(fn)
+        def _wrapped(*args, **kwargs):
+            try:
+                return fn(*args, **kwargs)
+            except Exception:  # noqa: BLE001
+                log.exception("chart callback %s raised", getattr(fn, "__name__", fn))
+        return _wrapped

--- a/tools/Python/PyDemo/chart/chart_window.py
+++ b/tools/Python/PyDemo/chart/chart_window.py
@@ -1,0 +1,767 @@
+"""Companion lightweight-charts window: candles + volume + live ticks + overlays.
+
+Phase 1: live candlesticks + volume for the subscribed contract, topbar interval
+switcher, up-front history load. Phase 2 adds native overlays driven by account
+updates: working-order lines (draggable to revise), a net-position / average-fill
+line, fill markers, SMA/EMA/VWAP indicators, and toolbox drawings with per-symbol
+persistence. The window runs in its own process via ``show_async`` on the app loop.
+
+Wiring (done in ``main.py``):
+    cw = ChartWindow(client, loop)
+    client.on_market_update = cw.on_market_update      # live ticks + market switch
+    client.on_account_update = cw.on_account_update    # orders / positions / fills
+    asyncio.ensure_future(cw.run())                    # opens the window
+
+The chart pulls historical bars itself through :class:`chart.history.ChartHistory`
+(run in a thread executor so the synchronous HTTP call never blocks the loop).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+import pandas as pd
+from lightweight_charts import Chart
+
+from . import _lwc_patches
+from .aggregator import CandleAggregator, TickStore
+from .bridge import CallbackBridge
+from .convert import parse_trade_string
+from .history import ChartHistory
+from .features.order_lines import OrderLines
+from .features.position_line import PositionLine
+from .features.fill_markers import FillMarkers
+from .features.indicators import Indicators
+from .features.drawings import Drawings
+from .features.order_tools import OrderTools
+
+log = logging.getLogger("pydemo.chart.window")
+
+# Shrink setData payloads (compact JSON) so large initial loads and scroll-grown
+# history render fully instead of partially. Applied at import (parent process).
+_lwc_patches.apply_patches()
+
+# Interval switcher: label -> seconds.
+_INTERVALS: list[tuple[str, int]] = [("15s", 15), ("1m", 60), ("5m", 300), ("15m", 900)]
+_LABEL_TO_SEC = dict(_INTERVALS)
+_SEC_TO_LABEL = {s: l for l, s in _INTERVALS}
+
+# Injected once, post-load. lightweight-charts' Line.delete() (used by our
+# indicator overlays) runs `legend.div.removeChild(legendItem.row)` — but the
+# legend row is actually a child of a nested `seriesContainer`, NOT `legend.div`
+# (bundle.js builds it with `seriesContainer.appendChild(row)`). So removeChild
+# is called on the WRONG parent: natively it throws `NotFoundError`, which
+# surfaces in the webview message-pump thread (chart.py loop), gets RE-RAISED,
+# and kills the pump — freezing the chart wherever it was left.
+#
+# We can't patch that loop (it runs in the webview subprocess), so we fix it at
+# the source in the page: redirect removeChild to the node's REAL parent. This
+# (1) never throws, so the pump survives, and (2) actually detaches the legend
+# row, so stale SMA/EMA/VWAP entries don't pile up on every reload. The normal
+# case (node is a direct child) is unchanged.
+_DOM_GUARD_JS = r"""
+(function () {
+  if (window.__pydemoDomGuard) return;
+  window.__pydemoDomGuard = true;
+  var orig = Node.prototype.removeChild;
+  Node.prototype.removeChild = function (child) {
+    if (child == null) return child;
+    var p = child.parentNode;
+    if (p == null) return child;                 // already detached: no-op, don't throw
+    if (p !== this) return p.removeChild(child);  // wrong parent: detach from the real one
+    return orig.call(this, child);                // normal path
+  };
+})();
+"""
+
+
+def lookback_days(interval_seconds: int, target_bars: int,
+                  initial_load_days: int, max_load_days: int) -> int:
+    """How many days of history to request so each interval loads a comparable
+    bar count. The T4 endpoint takes a date range (not a bar count), so we derive
+    the span from the interval: a fixed window made higher intervals look
+    truncated (e.g. ~184 bars at 15m vs ~2880 at 1m over the same 2 days).
+    Targets ``target_bars`` using a conservative ~23h trading day (futures run
+    nearly 24h), floored at ``initial_load_days`` and clamped to ``max_load_days``.
+    """
+    import math
+    target = max(1, target_bars)
+    if interval_seconds >= 86400:        # daily+ -> calendar days ~= bars
+        days = target
+    else:
+        seconds_per_trading_day = 23 * 3600
+        days = math.ceil(target * interval_seconds / seconds_per_trading_day)
+    days = max(initial_load_days, days)
+    return min(days, max_load_days)
+
+
+def scroll_buffer_bars(interval_seconds: int, scroll_buffer_days: float,
+                       floor: int = 20) -> int:
+    """How many loaded bars to keep off the left edge before prefetching older
+    history. Scales with the interval so the look-ahead is a consistent span of
+    time at every zoom (JSDemo parity: ``max(20, ceil(bars_per_day *
+    SCROLL_BUFFER_DAYS))``, ``SCROLL_BUFFER_DAYS = 1``). Once fewer than this many
+    bars remain to the left of the viewport, the loader pulls the next chunk so
+    bars are already there by the time the user scrolls to them."""
+    import math
+    bars_per_day = 86400 / max(1, interval_seconds)
+    return max(floor, math.ceil(bars_per_day * max(0.0, scroll_buffer_days)))
+
+
+def _fmt_range_ts(dt: datetime) -> str:
+    """Format a datetime as the T4 barchart range string (``YYYY-MM-DDThh:mm:ss``)."""
+    return dt.strftime("%Y-%m-%dT%H:%M:%S")
+
+
+def older_window(oldest_time: datetime, chunk_days: int) -> tuple[datetime, str, str]:
+    """One older chunk to fetch: ``[oldest - chunk_days .. oldest]``.
+
+    Returns ``(start_dt, start_str, end_str)``. End is the current oldest loaded
+    bar; start steps ``chunk_days`` back, floored to that day's 00:00 so a partial
+    leading day is fully covered. ``start_dt`` (tz preserved from ``oldest_time``)
+    is the next walk-back cursor; the strings are for the T4 range params."""
+    end = oldest_time
+    start_dt = (end - timedelta(days=max(1, chunk_days))).replace(
+        hour=0, minute=0, second=0, microsecond=0)
+    return start_dt, _fmt_range_ts(start_dt), _fmt_range_ts(end)
+
+
+def merge_older_bars(existing: list[dict], older: list[dict]) -> tuple[list[dict], int]:
+    """Prepend ``older`` bars before ``existing``, returning ``(merged, prepended)``.
+
+    Sorts ascending and drops duplicates at whole-second resolution (keeping the
+    last bar at each second), matching ``ChartWindow._bars_df``'s rule so the
+    candle series stays strictly ascending/unique. ``prepended`` is how many bars
+    were actually added to the left (after de-dup) — used to restore scroll pos.
+    """
+    if not older:
+        return existing, 0
+    before = len(existing)
+    by_sec: dict[int, dict] = {}
+    for bar in [*older, *existing]:           # existing wins on a tie (later)
+        sec = int(pd.Timestamp(bar["time"]).timestamp())
+        by_sec[sec] = bar
+    merged = [by_sec[s] for s in sorted(by_sec)]
+    return merged, max(0, len(merged) - before)
+
+
+class _Tag:
+    """Minimal stand-in for a topbar widget, exposing ``value`` + ``set``.
+
+    This bundled lightweight-charts build's topbar misbehaves with multiple
+    widgets, so drawings persistence keys off this in-memory tag instead of a
+    real textbox widget.
+    """
+
+    def __init__(self, value: str = "") -> None:
+        self.value = value
+
+    def set(self, value: str) -> None:
+        self.value = value
+
+
+class ChartWindow:
+    def __init__(
+        self,
+        client,
+        loop: asyncio.AbstractEventLoop,
+        *,
+        default_interval_seconds: int = 60,
+        initial_load_days: int = 2,
+        tz_offset_hours: float = 0.0,
+        target_bars: int = 500,
+        max_load_days: int = 120,
+        chunk_days: int = 1,
+        scroll_buffer_days: float = 1.0,
+        history_floor: str = "2000-01-01",
+    ) -> None:
+        self._client = client
+        self._loop = loop
+        self._bridge = CallbackBridge(loop)
+        self._interval = default_interval_seconds
+        self._initial_load_days = initial_load_days
+        self._target_bars = target_bars
+        self._max_load_days = max_load_days
+        self._chunk_days = max(1, chunk_days)            # older-history paging step
+        self._scroll_buffer_days = scroll_buffer_days    # interval-scaled trigger span
+        self._history_floor = self._parse_floor(history_floor)
+        self._tz_offset_hours = tz_offset_hours
+
+        self._chart: Optional[Chart] = None
+        self._ticks = TickStore()
+        self._agg = CandleAggregator(default_interval_seconds)
+
+        # Phase 2 features (created in run() once the chart exists).
+        self._order_lines: Optional[OrderLines] = None
+        self._position_line: Optional[PositionLine] = None
+        self._fill_markers: Optional[FillMarkers] = None
+        self._indicators: Optional[Indicators] = None
+        self._drawings: Optional[Drawings] = None
+        self._order_tools: Optional[OrderTools] = None
+        self._tools_installed = False  # order-tools JS injected post-load (once)
+
+        # Per-active-market state.
+        self._loaded_market_id: Optional[str] = None
+        self._load_gen = 0           # bumped per load request; stale loads abort
+        self._ready = False          # history loaded for the active market?
+        self._last_ttv = 0           # cumulative traded volume seen (de-dupe)
+        self._last_price: Optional[float] = None  # latest numeric trade price
+        self._history_bars: list = []            # last-loaded bars (for backtester)
+        self._history_interval = default_interval_seconds  # their interval (seconds)
+
+        # Infinite scroll-back state: the cumulative ascending bar set currently
+        # rendered, the oldest-loaded time (paging cursor), and re-entrancy/stop
+        # guards. Reset whenever a base load starts (market switch / interval).
+        self._loaded_bars: list = []
+        self._oldest_loaded_time: Optional[datetime] = None
+        self._loading_older = False
+        self._no_more_history = False
+        # Latest off-left-edge bar count seen on a range_change, plus a pending
+        # re-arm timer. The lightweight-charts range_change event self-throttles
+        # (unsubscribes, fires once, re-subscribes 50ms later), so events during
+        # an in-flight fetch are dropped; after each fetch we re-check this cached
+        # position and re-fire while the user is still pinned at the edge.
+        self._last_bars_before: Optional[float] = None
+        self._rearm_handle = None
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def run(self) -> None:
+        """Build the chart and run its window until closed."""
+        chart = Chart(title="PyDemo Chart", inner_width=1, inner_height=1, toolbox=True)
+        self._chart = chart
+        chart.legend(visible=True)
+        chart.candle_style(
+            up_color="#26a69a", down_color="#ef5350",
+            wick_up_color="#26a69a", wick_down_color="#ef5350",
+        )
+        chart.volume_config(up_color="#26a69a64", down_color="#ef535064")
+        chart.topbar.switcher(
+            "interval", tuple(l for l, _ in _INTERVALS),
+            default=_SEC_TO_LABEL.get(self._interval, "1m"),
+            func=self._bridge.guard(self._on_interval_change),
+        )
+        # NOTE: only the interval switcher lives on the topbar — this bundled
+        # build breaks with multiple topbar widgets. All Phase 3 controls live in
+        # the custom-JS context menu instead. Indicators are shown by default.
+        self._draw_tag = _Tag()
+
+        # Instantiate features now that the chart exists.
+        self._order_lines = OrderLines(chart, self._bridge, self._client)
+        self._position_line = PositionLine(chart)
+        self._fill_markers = FillMarkers(chart)
+        self._indicators = Indicators(chart)
+        self._drawings = Drawings(chart, self._draw_tag,
+                                  persist_path=self._drawings_path())
+        self._order_tools = OrderTools(
+            chart, self._bridge, self._client,
+            order_provider=lambda: {
+                uid: info["price"]
+                for uid, info in (self._order_lines._orders.items()
+                                  if self._order_lines else [])
+            },
+            last_price_provider=lambda: self._last_price,
+            indicators=self._indicators,
+        )
+        # NOTE: order-tools JS and the click subscription are installed *after*
+        # the window loads (in _load_history) — injecting custom JS into the
+        # pre-load script batch corrupts the topbar in this bundled build.
+
+        try:
+            await chart.show_async()
+        except Exception:  # noqa: BLE001
+            log.exception("chart window terminated unexpectedly")
+        finally:
+            self._chart = None
+
+
+    def _install_dom_guards(self) -> None:
+        """Make page DOM removal tolerant of already-detached nodes so a stale
+        legend-row delete can't throw and kill the webview message pump.
+
+        See ``_DOM_GUARD_JS``. Runs once, post-load (pre-load injection corrupts
+        the topbar in this bundled build); persists in the page across
+        ``chart.set()`` (which only re-sets data, it does not reload the page).
+        """
+        if self._chart is None:
+            return
+        try:
+            self._chart.run_script(_DOM_GUARD_JS)
+        except Exception:  # noqa: BLE001
+            log.exception("chart: failed to install DOM guards")
+
+    @staticmethod
+    def _drawings_path() -> str:
+        base = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                            "config")
+        return os.path.join(base, "chart_drawings.json")
+
+    # ------------------------------------------------------------------
+    # App -> chart
+    # ------------------------------------------------------------------
+
+    def _chart_live(self) -> bool:
+        """True while the chart window is usable. ``is_alive`` flips False when
+        the window closes (in show_async), *before* run()'s finally nulls
+        ``self._chart`` — so checking it stops callbacks issuing operations on a
+        disposed WebView2 (the ``ObjectDisposedException`` teardown race)."""
+        return self._chart is not None and getattr(self._chart, "is_alive", True)
+
+    def on_market_update(self, data: dict) -> None:
+        """Sync callback from ``client.on_market_update`` (on the asyncio loop)."""
+        if not self._chart_live():
+            return
+        market_id = data.get("market_id")
+        if not market_id:
+            return
+
+        # Market switch -> reset overlays and (re)load history for the new market.
+        if market_id != self._loaded_market_id:
+            self._loaded_market_id = market_id
+            self._ready = False
+            self._last_ttv = 0
+            for feat in (self._order_lines, self._position_line, self._fill_markers):
+                if feat is not None:
+                    feat.set_market(market_id)
+            self._load_gen += 1
+            gen = self._load_gen
+            self._bridge.run_coro(lambda mid=market_id, g=gen: self._load_history(mid, g))
+            return
+
+        if not self._ready:
+            # Capture a live price for JSON scale calibration while loading.
+            self._capture_price(data)
+            return
+
+        self._handle_trade(data)
+
+    def _capture_price(self, data: dict) -> None:
+        price, _ = self._extract_trade(data)
+        if price is not None:
+            self._last_price = price
+
+    def _handle_trade(self, data: dict) -> None:
+        price, volume = self._extract_trade(data)
+        if price is None:
+            return
+        self._last_price = price
+
+        # De-dupe: only aggregate when cumulative traded volume advances.
+        ttv = int(data.get("total_traded_volume") or 0)
+        if ttv:
+            if ttv <= self._last_ttv:
+                return
+            self._last_ttv = ttv
+        # else: ttv unavailable - process each trade tick (may slightly
+        # over-count volume; OHLC remains correct).
+
+        ts = time.time()
+        self._ticks.push(self._loaded_market_id, {"price": price, "volume": volume, "time": ts})
+        bar = self._agg.add_tick(price, volume, ts)
+        if bar is not None:
+            self._chart.update(self._bar_series(bar))
+            if self._indicators is not None:
+                self._indicators.on_bar(bar)
+
+    def on_account_update(self, data: dict) -> None:
+        """Sync callback from ``client.on_account_update`` (on the asyncio loop).
+
+        Routes order/position/fill events to the matching overlay feature,
+        filtered to the chart's active market.
+        """
+        if not self._chart_live() or not self._loaded_market_id:
+            return
+        kind = data.get("type")
+        market_id = self._loaded_market_id
+        try:
+            if kind == "orders" and self._order_lines is not None:
+                self._order_lines.update(data.get("orders", []), market_id)
+            elif kind == "positions" and self._position_line is not None:
+                self._position_line.update(data.get("positions", []), market_id)
+            elif kind == "fill" and self._fill_markers is not None:
+                self._fill_markers.add(data, market_id)
+        except Exception:  # noqa: BLE001
+            log.exception("chart on_account_update(%s) failed", kind)
+
+    @staticmethod
+    def _extract_trade(data: dict) -> tuple[Optional[float], int]:
+        """Pull (price, volume) from the market-update payload."""
+        price = data.get("last_trade_price")
+        volume = data.get("last_trade_volume") or 0
+        if price is not None:
+            try:
+                return float(price), int(volume)
+            except (ValueError, TypeError):
+                pass
+        # Fallback to the formatted "volume@price" string.
+        parsed = parse_trade_string(data.get("last_trade", "-"))
+        if parsed:
+            return parsed
+        return None, 0
+
+    # ------------------------------------------------------------------
+    # History loading
+    # ------------------------------------------------------------------
+
+    async def _fetch_bars(self, market_id, exchange_id, contract_id, interval,
+                          start, end, live_price):
+        """Fetch + normalise bars for one date window (in the executor so the
+        synchronous HTTP/decoder never blocks the loop). Returns ``(bars, source)``;
+        ``([], "none")`` on failure."""
+        token = self._client.jw_token
+        base_url = self._chart_base_url()
+
+        def _fetch():
+            hist = ChartHistory(token, base_url=base_url,
+                                tz_offset_hours=self._tz_offset_hours)
+            try:
+                return hist.fetch(
+                    exchange_id=exchange_id,
+                    contract_id=contract_id,
+                    market_id=market_id,
+                    interval_seconds=interval,
+                    trade_date_start=start,
+                    trade_date_end=end,
+                    live_price=live_price,
+                )
+            finally:
+                hist.close()
+
+        try:
+            return await self._loop.run_in_executor(None, _fetch)
+        except Exception:  # noqa: BLE001
+            log.exception("chart: history fetch failed for %s [%s .. %s]",
+                          market_id, start, end)
+            return [], "none"
+
+    async def _load_history(self, market_id: str, gen: int) -> None:
+        """Base load for the active market/interval. Replaces the rendered data
+        and resets the scroll-back cursor; older bars are then paged in lazily by
+        :meth:`_load_older` as the user scrolls left."""
+        details = self._client.market_details.get(market_id)
+        exchange_id = getattr(details, "exchange_id", None) or self._client.md_exchange_id
+        contract_id = getattr(details, "contract_id", None) or self._client.md_contract_id
+        decimals = self._decimals(details)
+
+        if not self._client.jw_token:
+            log.warning("chart: no auth token yet; skipping history load")
+            return
+
+        start, end = self._date_range()
+        interval = self._interval
+        bars, source = await self._fetch_bars(
+            market_id, exchange_id, contract_id, interval, start, end, self._last_price)
+
+        # A later load request (interval switch or market switch) may have
+        # superseded this one. Abort BEFORE any chart mutation so only the newest
+        # load runs set()/recompute() — otherwise concurrent passes stack
+        # duplicate indicator line series (chart.set() doesn't wipe create_line).
+        # The mutate block below has no await, so once past here it's atomic.
+        if gen != self._load_gen or market_id != self._loaded_market_id \
+                or not self._chart_live():
+            return
+
+        # This is the base load: reset the cumulative scroll-back state.
+        self._history_bars = bars            # backtester reads on-screen bars
+        self._history_interval = interval
+        self._loaded_bars = list(bars)
+        self._oldest_loaded_time = bars[0]["time"] if bars else None
+        self._no_more_history = False
+        self._loading_older = False
+        self._last_bars_before = None
+        if self._rearm_handle is not None:
+            self._rearm_handle.cancel()
+            self._rearm_handle = None
+
+        df = self._bars_df(self._loaded_bars)
+        try:
+            self._chart.precision(decimals)
+            self._chart.set(df)
+            # Fit only on a base load: show the freshly-loaded window. (Scroll-back
+            # prepends must NOT fit — that would jump the viewport.)
+            self._chart.fit()
+            self._chart.watermark(f"{contract_id} {_SEC_TO_LABEL.get(interval, '')}")
+        except Exception:  # noqa: BLE001 - surface webview/data errors, don't blank silently
+            log.exception("chart: failed to render %d bars for %s", len(df), market_id)
+            return
+
+        self._agg.reset(interval)
+        if bars:
+            self._agg.seed_last_bar(bars[-1])
+        self._ready = True
+
+        # Install order-tools JS + event subscriptions once, now that the window
+        # has loaded (pre-load injection corrupts the topbar in this build).
+        if not self._tools_installed and self._order_tools is not None:
+            self._install_dom_guards()  # must precede any line.delete() (later loads)
+            self._order_tools.install()
+            self._chart.events.click += self._bridge.guard(self._order_tools.on_click)
+            self._chart.events.range_change += self._bridge.guard(self._on_range_change)
+            self._tools_installed = True
+
+        self._render_overlays(df, contract_id or market_id)
+        self._log_loaded(df, source, exchange_id, contract_id)
+
+    def _render_overlays(self, df, contract_id) -> None:
+        """Rebuild indicator/order/position/fill/drawing overlays after a
+        ``chart.set()`` (which wipes toolbox drawings and leaves stale line refs)."""
+        try:
+            if self._indicators is not None:
+                self._indicators.recompute(df)
+            if self._order_lines is not None:
+                self._order_lines.rebuild()
+            if self._position_line is not None:
+                self._position_line.rebuild()
+            if self._fill_markers is not None:
+                self._fill_markers.rebuild()
+            if self._drawings is not None:
+                self._drawings.set_symbol(contract_id)
+        except Exception:  # noqa: BLE001
+            log.exception("chart: overlay rebuild failed")
+
+    @staticmethod
+    def _log_loaded(df, source, exchange_id, contract_id) -> None:
+        first_t = df["time"].iloc[0] if not df.empty else None
+        last_t = df["time"].iloc[-1] if not df.empty else None
+        log.info("chart: loaded %d bars (%s) for %s/%s [%s .. %s]",
+                 len(df), source, exchange_id, contract_id, first_t, last_t)
+
+    # ------------------------------------------------------------------
+    # Scroll-back (infinite history) loading
+    # ------------------------------------------------------------------
+
+    def _on_range_change(self, chart, bars_before: float, bars_after: float) -> None:
+        """Fires on scroll/pan (on the asyncio loop). When the user nears the left
+        edge, lazily fetch + prepend older history (JSDemo-style)."""
+        # Track the latest position even when guarded below — the re-arm uses it.
+        if bars_before is not None:
+            self._last_bars_before = bars_before
+        if not self._ready or not self._chart_live():
+            return
+        if self._loading_older or self._no_more_history:
+            return
+        if self._oldest_loaded_time is None or bars_before is None:
+            return
+        if bars_before >= self._scroll_buffer_bars():
+            return
+        asyncio.ensure_future(self._load_older(self._load_gen))
+
+    def _scroll_buffer_bars(self) -> int:
+        """Interval-scaled left-edge trigger threshold (see module helper)."""
+        return scroll_buffer_bars(self._interval, self._scroll_buffer_days)
+
+    async def _load_older(self, gen: int) -> None:
+        """Fetch the next older chunk(s) and prepend them, preserving scroll
+        position. Walks backward over empty (weekend/holiday) windows up to a few
+        attempts; stops at ``history_floor``."""
+        if (self._loading_older or self._no_more_history or not self._ready
+                or self._oldest_loaded_time is None or not self._chart_live()):
+            return
+        market_id = self._loaded_market_id
+        details = self._client.market_details.get(market_id)
+        exchange_id = getattr(details, "exchange_id", None) or self._client.md_exchange_id
+        contract_id = getattr(details, "contract_id", None) or self._client.md_contract_id
+        interval = self._interval
+
+        self._loading_older = True
+        try:
+            end = self._oldest_loaded_time
+            older: list = []
+            for _attempt in range(14):           # skip empty weekend/holiday windows
+                if end <= self._history_floor:
+                    self._no_more_history = True
+                    break
+                start_dt, start_s, end_s = older_window(end, self._chunk_days)
+                bars, _src = await self._fetch_bars(
+                    market_id, exchange_id, contract_id, interval,
+                    start_s, end_s, self._last_price)
+                # Superseded by a market/interval switch while fetching?
+                if gen != self._load_gen or market_id != self._loaded_market_id \
+                        or not self._chart_live():
+                    return
+                older = [b for b in bars if b["time"] < self._oldest_loaded_time]
+                if older:
+                    break
+                end = start_dt                   # nothing new here; step further back
+                if end <= self._history_floor:
+                    self._no_more_history = True
+                    break
+
+            if not older:
+                return
+
+            merged, prepended = merge_older_bars(self._loaded_bars, older)
+            if prepended == 0:
+                return
+            self._loaded_bars = merged
+            self._oldest_loaded_time = merged[0]["time"]
+            self._history_bars = merged          # keep backtester cache in sync
+            # _restore_scroll shifts the view right by `prepended`; mirror that on
+            # the cached position so the re-arm sees the post-shift edge distance
+            # without waiting on the (throttled) range_change to re-fire.
+            self._last_bars_before = (self._last_bars_before or 0) + prepended
+
+            df = self._bars_df(self._loaded_bars)
+            try:
+                self._chart.set(df)              # NO fit() — would jump the viewport
+                self._restore_scroll(prepended)  # shift view right by prepended bars
+            except Exception:  # noqa: BLE001
+                log.exception("chart: failed to render older bars for %s", market_id)
+                return
+            self._render_overlays(df, contract_id or market_id)
+            log.info("chart: +%d older bars (%d total) for %s, oldest now %s",
+                     prepended, len(df), contract_id,
+                     df["time"].iloc[0] if not df.empty else None)
+        finally:
+            self._loading_older = False
+            # A single drag fires range_change once, then the lib goes deaf for
+            # ~50ms; events arriving mid-fetch are dropped by the guard above. Re-
+            # check on the next tick so continuous scrolling keeps pulling chunks
+            # instead of stalling after one (JSDemo _scheduleOlderHistoryRearm).
+            self._schedule_older_rearm()
+
+    def _schedule_older_rearm(self) -> None:
+        """Re-fire ``_load_older`` shortly after a fetch if the user is still near
+        the left edge. Self-terminating: each chunk's ``_restore_scroll`` pushes
+        ``_last_bars_before`` back above the threshold once the buffer refills."""
+        if self._no_more_history or self._rearm_handle is not None:
+            return
+
+        def _rearm():
+            self._rearm_handle = None
+            if (self._loading_older or self._no_more_history
+                    or not self._ready or not self._chart_live()):
+                return
+            if (self._last_bars_before is not None
+                    and self._last_bars_before < self._scroll_buffer_bars()):
+                asyncio.ensure_future(self._load_older(self._load_gen))
+
+        # 50ms > the lib's range_change re-subscribe delay, ≈ JSDemo's rAF re-arm.
+        self._rearm_handle = self._loop.call_later(0.05, _rearm)
+
+    def _restore_scroll(self, prepended: int) -> None:
+        """After prepending ``prepended`` bars and re-``set()``-ing, shift the
+        visible logical range right by that many bars so the user stays on the same
+        candles (``set()`` preserves logical indices, which now point further back)."""
+        if prepended <= 0 or self._chart is None:
+            return
+        try:
+            self._chart.run_script(f'''
+            (function () {{
+                var ts = {self._chart.id}.chart.timeScale();
+                var r = ts.getVisibleLogicalRange();
+                if (r) ts.setVisibleLogicalRange({{from: r.from + {prepended}, to: r.to + {prepended}}});
+            }})()''')
+        except Exception:  # noqa: BLE001
+            log.exception("chart: failed to restore scroll position")
+
+    def _on_interval_change(self, chart) -> None:
+        label = chart.topbar["interval"].value
+        seconds = _LABEL_TO_SEC.get(label)
+        if not seconds or seconds == self._interval:
+            return
+        self._interval = seconds
+        self._agg.reset(seconds)
+        self._ready = False
+        if self._loaded_market_id:
+            mid = self._loaded_market_id
+            self._load_gen += 1
+            gen = self._load_gen
+            self._bridge.run_coro(lambda m=mid, g=gen: self._load_history(m, g))
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _parse_floor(s: str) -> datetime:
+        """Parse the configured history floor into a tz-aware UTC datetime (the
+        oldest date scroll-back will page to). Falls back to 2000-01-01 on junk."""
+        try:
+            dt = datetime.fromisoformat(str(s))
+        except (ValueError, TypeError):
+            dt = datetime(2000, 1, 1)
+        return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+
+    def _decimals(self, details) -> int:
+        if details is None:
+            return 2
+        if getattr(self._client, "priceFormat", 0):
+            return int(getattr(details, "real_decimals", None)
+                       or getattr(details, "decimals", 2) or 2)
+        return int(getattr(details, "decimals", 2) or 2)
+
+    def _chart_base_url(self) -> Optional[str]:
+        api = getattr(self._client, "apiUrl", None)
+        if not api:
+            return None
+        return api.rstrip("/") + "/chart"
+
+    def _date_range(self) -> tuple[str, str]:
+        now = datetime.now(timezone.utc)
+        days = self._lookback_days(self._interval)
+        start = (now - timedelta(days=days)).strftime("%Y-%m-%dT00:00:00")
+        end = now.strftime("%Y-%m-%dT23:59:59")
+        return start, end
+
+    def _lookback_days(self, interval_seconds: int) -> int:
+        return lookback_days(interval_seconds, self._target_bars,
+                             self._initial_load_days, self._max_load_days)
+
+    @staticmethod
+    def _to_ns(times) -> pd.Series:
+        """Normalise a time column/series to tz-naive ``datetime64[ns]``.
+
+        lightweight-charts converts time with ``astype('int64') // 10**9``,
+        which assumes nanosecond resolution. pandas >= 3.0 defaults to
+        microsecond (``datetime64[us]``) resolution, so without this the
+        library's conversion collapses every bar to a single timestamp and the
+        chart renders one candle. Forcing ``[ns]`` keeps it correct on any
+        pandas version.
+        """
+        return pd.to_datetime(times, utc=True).dt.tz_localize(None).astype("datetime64[ns]")
+
+    @classmethod
+    def _bars_df(cls, bars: list[dict], max_bars: Optional[int] = None) -> pd.DataFrame:
+        cols = ["time", "open", "high", "low", "close", "volume"]
+        if not bars:
+            return pd.DataFrame(columns=cols)
+        df = pd.DataFrame(bars, columns=cols)
+        df["time"] = cls._to_ns(df["time"])
+        # Force float OHLC so a later fractional live update() never hits pandas
+        # 3.0's "Invalid value for dtype int64" when prices happen to be whole.
+        for col in ("open", "high", "low", "close"):
+            df[col] = df[col].astype("float64")
+        # lightweight-charts truncates `time` to whole seconds and requires
+        # strictly-ascending, unique timestamps; otherwise setData rejects the
+        # whole array in the webview. Sort and drop second-level duplicates
+        # (keeping the last/most-complete bar at each second).
+        df = df.sort_values("time")
+        sec = df["time"].astype("int64") // 10 ** 9
+        df = df[~sec.duplicated(keep="last")].reset_index(drop=True)
+        # Cap the *rendered* bar count. At dense intervals (e.g. 15s) the load
+        # window yields ~15k bars; lightweight-charts serialises them with
+        # json.dumps(indent=2) into a multi-MB setData() script that WebView2
+        # renders only partially ("half-loaded"). Keep the most recent max_bars
+        # for display; the caller still caches the full set for the backtester.
+        if max_bars and len(df) > max_bars:
+            df = df.iloc[-max_bars:].reset_index(drop=True)
+        return df
+
+    @staticmethod
+    def _bar_series(bar: dict) -> pd.Series:
+        return pd.Series({
+            "time": bar["time"],
+            "open": bar["open"],
+            "high": bar["high"],
+            "low": bar["low"],
+            "close": bar["close"],
+            "volume": bar["volume"],
+        })

--- a/tools/Python/PyDemo/chart/convert.py
+++ b/tools/Python/PyDemo/chart/convert.py
@@ -1,0 +1,93 @@
+"""Pure conversion helpers: T4 ``NDateTime`` / ``Price`` -> chart units.
+
+The chart layer (lightweight-charts) wants plain Python ``datetime`` objects and
+``float`` prices. The T4 binary decoder (``t4login``) produces:
+
+* ``NDateTime`` - .NET-style ticks (100 ns) since 0001-01-01. We convert to a
+  UTC epoch second and then to a ``datetime``.
+* ``Price`` - a ``decimal.Decimal`` wrapper already in *real display units*
+  (e.g. ``4525.50``) once the decoder has applied the market's tick size, so a
+  decoded bar's OHLC only needs ``float(price.value)``.
+
+These functions are deliberately free of any I/O or charting dependency so they
+can be unit-tested against the ``t4login`` fixtures.
+
+Timezone note
+-------------
+The bar ``Time`` encoded by T4 is the exchange/session wall-clock, not UTC.
+``ndatetime_to_epoch_seconds`` reads that wall-clock *as if* it were UTC. Live
+ticks (timestamped with ``time.time()``) are true UTC, so if the exchange is not
+on UTC the two streams can be offset by a constant. ``tz_offset_hours`` lets the
+caller correct that; it defaults to 0 and is a calibration knob exercised during
+live verification (compare the last historical bar time to "now").
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Any
+
+# Ticks (100 ns units) between 0001-01-01 and the Unix epoch (1970-01-01).
+EPOCH_TICKS: int = 621_355_968_000_000_000
+TICKS_PER_SECOND: int = 10_000_000
+
+
+def ndatetime_to_epoch_seconds(ndt: Any, tz_offset_hours: float = 0.0) -> int:
+    """Convert an ``NDateTime`` (or anything exposing ``.ticks``) to a UTC
+    epoch second, applying an optional whole/fractional hour offset."""
+    ticks = ndt.ticks if hasattr(ndt, "ticks") else int(ndt)
+    seconds = (ticks - EPOCH_TICKS) // TICKS_PER_SECOND
+    return int(seconds + tz_offset_hours * 3600)
+
+
+def ndatetime_to_datetime(ndt: Any, tz_offset_hours: float = 0.0) -> datetime:
+    """Convert an ``NDateTime`` to a timezone-aware UTC ``datetime`` suitable
+    for a lightweight-charts ``time`` column."""
+    return datetime.fromtimestamp(
+        ndatetime_to_epoch_seconds(ndt, tz_offset_hours), tz=timezone.utc
+    )
+
+
+def price_to_float(price: Any) -> float:
+    """Convert a decoded ``Price`` (or ``Decimal``/number/str) to ``float``.
+
+    Decoded bar prices are already in real display units, so this is a plain
+    numeric cast - but we route through ``Decimal`` to avoid surprises from
+    binary-float string parsing.
+    """
+    if price is None:
+        return float("nan")
+    value = getattr(price, "value", price)
+    if isinstance(value, Decimal):
+        return float(value)
+    return float(Decimal(str(value)))
+
+
+def bar_to_dict(bar: Any, tz_offset_hours: float = 0.0) -> dict:
+    """Normalise a decoded ``t4login`` ``Bar`` into the chart's bar dict.
+
+    Returns ``{time: datetime, open, high, low, close: float, volume: int}``.
+    """
+    return {
+        "time": ndatetime_to_datetime(bar.Time, tz_offset_hours),
+        "open": price_to_float(bar.OpenPrice),
+        "high": price_to_float(bar.HighPrice),
+        "low": price_to_float(bar.LowPrice),
+        "close": price_to_float(bar.ClosePrice),
+        "volume": int(bar.Volume),
+    }
+
+
+def parse_trade_string(last_trade: str) -> tuple[float, int] | None:
+    """Parse PyDemo's ``"volume@price"`` last-trade string into ``(price, volume)``.
+
+    Returns ``None`` for the ``"-"`` placeholder or anything unparseable.
+    """
+    if not last_trade or last_trade == "-" or "@" not in last_trade:
+        return None
+    vol_str, _, price_str = last_trade.partition("@")
+    try:
+        return float(price_str), int(float(vol_str))
+    except (ValueError, TypeError):
+        return None

--- a/tools/Python/PyDemo/chart/features/__init__.py
+++ b/tools/Python/PyDemo/chart/features/__init__.py
@@ -1,0 +1,2 @@
+"""Phase 2 chart overlays: order lines, position line, fill markers, indicators,
+and toolbox drawings. Each feature is a small class driven by ChartWindow."""

--- a/tools/Python/PyDemo/chart/features/drawings.py
+++ b/tools/Python/PyDemo/chart/features/drawings.py
@@ -1,0 +1,60 @@
+"""Toolbox drawings with per-symbol persistence.
+
+Thin manager around the library's built-in toolbox (``Chart(toolbox=True)``),
+which provides trendline / ray / box / vertical-line tools and a per-drawing
+right-click menu natively. We add:
+
+* per-symbol save/load - drawings are keyed by the contract symbol via a topbar
+  textbox widget, so each contract keeps its own drawings;
+* cross-session persistence - drawings are imported from / exported to a JSON
+  file on disk.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+log = logging.getLogger("pydemo.chart.drawings")
+
+
+class Drawings:
+    def __init__(self, chart, symbol_widget, persist_path: str | None = None) -> None:
+        self._chart = chart
+        self._widget = symbol_widget
+        self._path = persist_path
+        self._tag = None
+
+        toolbox = getattr(chart, "toolbox", None)
+        if toolbox is None:
+            log.warning("chart has no toolbox; drawings disabled")
+            self._toolbox = None
+            return
+        self._toolbox = toolbox
+        if self._path and os.path.exists(self._path):
+            try:
+                toolbox.import_drawings(self._path)
+            except Exception:  # noqa: BLE001
+                log.exception("failed to import drawings from %s", self._path)
+        toolbox.save_drawings_under(symbol_widget)
+
+    def set_symbol(self, symbol: str) -> None:
+        """Switch the active drawing set to ``symbol`` (persist the previous)."""
+        if self._toolbox is None or not symbol:
+            return
+        # Persist whatever was drawn under the previous tag before switching.
+        self._export()
+        self._tag = symbol
+        try:
+            self._widget.set(symbol)
+            self._toolbox.load_drawings(symbol)
+        except Exception:  # noqa: BLE001
+            log.exception("failed to load drawings for %s", symbol)
+
+    def _export(self) -> None:
+        if self._toolbox is None or not self._path:
+            return
+        try:
+            self._toolbox.export_drawings(self._path)
+        except Exception:  # noqa: BLE001
+            log.exception("failed to export drawings to %s", self._path)

--- a/tools/Python/PyDemo/chart/features/fill_markers.py
+++ b/tools/Python/PyDemo/chart/features/fill_markers.py
@@ -1,0 +1,81 @@
+"""Trade-fill markers (buy/sell arrows at the fill price/time).
+
+Buy fills get an upward green arrow below the bar, sells a downward red arrow
+above. Fills are cached so they can be re-applied after a ``chart.set()`` and
+filtered to the active market.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+
+log = logging.getLogger("pydemo.chart.fill_markers")
+
+_BUY = 1
+
+
+class FillMarkers:
+    def __init__(self, chart) -> None:
+        self._chart = chart
+        self._fills: list[dict] = []   # cached normalised fills for active market
+        self._market_id = None
+
+    def set_market(self, market_id) -> None:
+        if market_id != self._market_id:
+            self._market_id = market_id
+            self._fills = []
+            try:
+                self._chart.clear_markers()
+            except Exception:  # noqa: BLE001
+                pass
+
+    def add(self, fill: dict, market_id) -> None:
+        """Handle an account 'fill' event."""
+        if fill.get("market_id") != market_id:
+            return
+        norm = self._normalise(fill)
+        if norm is None:
+            return
+        self._fills.append(norm)
+        self._place(norm)
+
+    def rebuild(self) -> None:
+        """Re-apply cached markers after a chart.set()."""
+        try:
+            self._chart.clear_markers()
+        except Exception:  # noqa: BLE001
+            pass
+        for f in self._fills:
+            self._place(f)
+
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _normalise(fill: dict):
+        price = fill.get("price")
+        ts = fill.get("time")
+        if price is None or ts is None:
+            return None
+        try:
+            return {
+                "time": datetime.fromtimestamp(int(ts), tz=timezone.utc).replace(tzinfo=None),
+                "price": float(price),
+                "volume": int(fill.get("volume", 0) or 0),
+                "side": fill.get("buy_sell", 0),
+            }
+        except (ValueError, TypeError, OSError):
+            return None
+
+    def _place(self, f: dict) -> None:
+        buy = f["side"] == _BUY
+        try:
+            self._chart.marker(
+                time=f["time"],
+                position="below" if buy else "above",
+                shape="arrow_up" if buy else "arrow_down",
+                color="#26a69a" if buy else "#ef5350",
+                text=f"{'B' if buy else 'S'} {f['volume']}@{f['price']}",
+            )
+        except Exception:  # noqa: BLE001
+            log.exception("failed to place fill marker")

--- a/tools/Python/PyDemo/chart/features/indicators.py
+++ b/tools/Python/PyDemo/chart/features/indicators.py
@@ -1,0 +1,182 @@
+"""SMA / EMA / VWAP indicator overlays.
+
+Pure math (``sma``/``ema``/``vwap``) is separated from the chart-bound
+``Indicators`` feature so it can be unit-tested. Indicators are drawn as
+additional line series via ``chart.create_line``; the full series is set on
+history load and the latest point is updated as bars close.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+import pandas as pd
+
+log = logging.getLogger("pydemo.chart.indicators")
+
+
+# --- pure math ---------------------------------------------------------------
+
+def sma(close: pd.Series, period: int) -> pd.Series:
+    return close.rolling(period).mean()
+
+
+def ema(close: pd.Series, period: int) -> pd.Series:
+    return close.ewm(span=period, adjust=False).mean()
+
+
+def vwap(df: pd.DataFrame, day_reset: bool = True) -> pd.Series:
+    """Volume-weighted average price; resets each UTC day by default."""
+    typical = (df["high"] + df["low"] + df["close"]) / 3.0
+    pv = typical * df["volume"]
+    vol = df["volume"]
+    if day_reset and not df.empty:
+        day = pd.to_datetime(df["time"]).dt.normalize()
+        cum_pv = pv.groupby(day).cumsum()
+        cum_v = vol.groupby(day).cumsum()
+    else:
+        cum_pv = pv.cumsum()
+        cum_v = vol.cumsum()
+    return cum_pv / cum_v.where(cum_v != 0)
+
+
+def compute(df: pd.DataFrame, kind: str, period: Optional[int]) -> pd.Series:
+    if kind == "sma":
+        return sma(df["close"], period or 20)
+    if kind == "ema":
+        return ema(df["close"], period or 50)
+    if kind == "vwap":
+        return vwap(df)
+    raise ValueError(f"unknown indicator kind: {kind}")
+
+
+# --- feature -----------------------------------------------------------------
+
+# (key, display name, kind, period, color)
+DEFAULT_SPECS = [
+    ("sma20", "SMA 20", "sma", 20, "#f0b90b"),
+    ("ema50", "EMA 50", "ema", 50, "#2196f3"),
+    ("vwap", "VWAP", "vwap", None, "#ab47bc"),
+]
+
+
+class Indicators:
+    def __init__(self, chart, specs=None) -> None:
+        self._chart = chart
+        self._specs = specs or DEFAULT_SPECS
+        self._spec_by_key = {s[0]: s for s in self._specs}
+        self._lines: dict[str, object] = {}
+        # _visible is the single source of truth: an indicator is on the chart
+        # iff it's visible. Default off; the context-menu toggle turns them on.
+        self._visible: dict[str, bool] = {s[0]: False for s in self._specs}
+        self._df: Optional[pd.DataFrame] = None
+        self._last_bar: Optional[dict] = None
+
+    def _build_line(self, key: str, name: str, kind: str, period, color: str) -> None:
+        """Create a fresh line series for one indicator and set its full series
+        from the current df. Caller guarantees df is present and the key is
+        meant to be visible."""
+        try:
+            values = compute(self._df, kind, period)
+            ldf = pd.DataFrame({"time": self._df["time"], name: values}).dropna()
+            line = self._chart.create_line(name=name, color=color, width=1,
+                                           price_line=False, price_label=False)
+            line.set(ldf)
+            self._lines[key] = line
+        except Exception:  # noqa: BLE001
+            log.exception("indicator %s build failed", key)
+
+    def _delete_all(self) -> None:
+        """Remove every indicator line series from the chart.
+
+        Unlike toolbox drawings (OrderLines' horizontal_line), ``create_line``
+        series are NOT wiped by ``chart.set()`` — so we must delete them
+        explicitly or they linger and overlap freshly-built lines.
+        """
+        for line in self._lines.values():
+            try:
+                line.delete()
+            except Exception:  # noqa: BLE001
+                pass
+        self._lines.clear()
+
+    def recompute(self, df: pd.DataFrame) -> None:
+        """Rebuild indicator series from freshly-loaded history.
+
+        ``chart.set()`` does NOT delete ``create_line`` series (it only resets
+        the candle data), so we delete the old indicator lines ourselves before
+        recreating ONLY the indicators that are currently visible. A toggled-off
+        indicator is simply never recreated, so "off" persists across switches.
+        """
+        self._df = df.copy() if df is not None else None
+        self._last_bar = None
+        self._delete_all()  # create_line series survive chart.set(); kill them
+        if self._df is None or self._df.empty:
+            return
+        for key, name, kind, period, color in self._specs:
+            if not self._visible.get(key, True):
+                continue
+            self._build_line(key, name, kind, period, color)
+
+    def on_bar(self, bar: dict) -> None:
+        """Advance indicators when a bar closes (one recompute per new bar)."""
+        if self._df is None:
+            return
+        ts = pd.Timestamp(bar["time"]).tz_localize(None)
+        prev = self._last_bar
+        self._last_bar = {**bar, "time": ts}
+
+        if prev is None or pd.Timestamp(prev["time"]).tz_localize(None) == ts:
+            # First bar seen, or still the same forming bar — wait for close.
+            return
+
+        # A new bar started: commit the previous (now-closed) bar and update.
+        self._df = pd.concat([self._df, pd.DataFrame([prev])], ignore_index=True)
+        sec = pd.to_datetime(self._df["time"]).astype("int64") // 10 ** 9
+        self._df = self._df[~sec.duplicated(keep="last")].reset_index(drop=True)
+
+        committed_time = pd.Timestamp(prev["time"]).tz_localize(None)
+        for key, name, kind, period, color in self._specs:
+            # Only update lines that exist (i.e. visible ones); skip toggled-off.
+            line = self._lines.get(key)
+            if line is None or not self._visible.get(key, True):
+                continue
+            try:
+                values = compute(self._df, kind, period)
+                last = values.iloc[-1]
+                if pd.notna(last):
+                    line.update(pd.Series({"time": committed_time, name: float(last)}))
+            except Exception:  # noqa: BLE001
+                log.exception("indicator %s update failed", key)
+
+    # -- toggle API (wired to the chart context menu) -------------------------
+    def is_visible(self, key: str) -> bool:
+        return bool(self._visible.get(key, True))
+
+    def specs_for_menu(self) -> list[dict]:
+        """[{key, label}] for building the context-menu toggle items."""
+        return [{"key": k, "label": name} for (k, name, _kind, _p, _c) in self._specs]
+
+    def set_visible(self, key: str, visible: bool) -> None:
+        """Live toggle (no reload). Builds the line on demand when turned on and
+        hides it when turned off; recompute() then honors the state on the next
+        history load / interval switch."""
+        self._visible[key] = visible
+        line = self._lines.get(key)
+        if visible:
+            if line is None:
+                if self._df is not None and not self._df.empty:
+                    spec = self._spec_by_key.get(key)
+                    if spec:
+                        self._build_line(*spec)
+            else:
+                try:
+                    line.show_data()
+                except Exception:  # noqa: BLE001
+                    pass
+        elif line is not None:
+            try:
+                line.hide_data()
+            except Exception:  # noqa: BLE001
+                pass

--- a/tools/Python/PyDemo/chart/features/order_lines.py
+++ b/tools/Python/PyDemo/chart/features/order_lines.py
@@ -1,0 +1,118 @@
+"""Working-order overlay lines (labeled, colored, draggable to revise).
+
+One draggable ``HorizontalLine`` per working order in the active market. Buy
+lines are green, sell lines red. Dragging a line calls ``client.revise_order``
+with the new price (scheduled on the asyncio loop via the bridge).
+
+Two redraw entry points are needed because ``Chart.set`` (history load /
+interval switch) wipes toolbox-managed drawings, including these lines:
+* :meth:`update` - order set changed (from an account update); rebuilds lines.
+* :meth:`rebuild` - called after a ``set()``; the JS primitives are already
+  gone, so it just drops stale refs and recreates from cached order state.
+"""
+
+from __future__ import annotations
+
+import logging
+
+log = logging.getLogger("pydemo.chart.order_lines")
+
+_WORKING_STATUS = 1
+_BUY = 1
+
+
+class OrderLines:
+    def __init__(self, chart, bridge, client) -> None:
+        self._chart = chart
+        self._bridge = bridge
+        self._client = client
+        self._lines: dict = {}     # unique_id -> HorizontalLine
+        self._orders: dict = {}    # unique_id -> {price, volume, side}
+        self._market_id = None
+
+    def set_market(self, market_id) -> None:
+        if market_id != self._market_id:
+            self._market_id = market_id
+            self._orders = {}
+            self._delete_all()
+
+    def update(self, orders, market_id) -> None:
+        """Refresh from a list of OrderUpdate protos (account 'orders' event)."""
+        self._market_id = market_id
+        working = {}
+        for o in orders:
+            if getattr(o, "market_id", None) != market_id:
+                continue
+            if getattr(o, "status", None) != _WORKING_STATUS:
+                continue
+            price = self._order_price(o)
+            if price is None:
+                continue
+            working[o.unique_id] = {
+                "price": float(price),
+                "volume": self._order_volume(o),
+                "side": getattr(o, "buy_sell", 0),
+            }
+        self._orders = working
+        self._delete_all()
+        self._create_all()
+
+    def rebuild(self) -> None:
+        """Recreate lines after a chart.set() wiped them."""
+        self._lines.clear()
+        self._create_all()
+
+    # ------------------------------------------------------------------
+
+    def _create_all(self) -> None:
+        for uid, info in self._orders.items():
+            self._create(uid, info)
+
+    def _create(self, uid, info) -> None:
+        color = "#26a69a" if info["side"] == _BUY else "#ef5350"
+        side = "BUY" if info["side"] == _BUY else "SELL"
+        text = f"{side} {info['volume']} @ {info['price']}"
+
+        def on_drag(chart, line, _uid=uid):
+            self._bridge.run_coro(lambda: self._revise(_uid, line.price))
+
+        try:
+            self._lines[uid] = self._chart.horizontal_line(
+                info["price"], color=color, width=2, style="dashed",
+                text=text, func=on_drag)
+        except Exception:  # noqa: BLE001
+            log.exception("failed to draw order line %s", uid)
+
+    async def _revise(self, uid, new_price) -> None:
+        info = self._orders.get(uid)
+        if not info:
+            return
+        try:
+            await self._client.revise_order(uid, int(info["volume"]),
+                                            float(new_price), "limit")
+            info["price"] = float(new_price)
+            log.info("revise order %s -> %s", uid, new_price)
+        except Exception:  # noqa: BLE001
+            log.exception("revise order %s failed", uid)
+
+    def _delete_all(self) -> None:
+        for line in self._lines.values():
+            try:
+                line.delete()
+            except Exception:  # noqa: BLE001
+                pass
+        self._lines.clear()
+
+    @staticmethod
+    def _order_price(o):
+        if o.HasField("current_limit_price"):
+            return o.current_limit_price.value
+        if o.HasField("new_limit_price"):
+            return o.new_limit_price.value
+        return None
+
+    @staticmethod
+    def _order_volume(o):
+        return (getattr(o, "working_volume", 0)
+                or getattr(o, "current_volume", 0)
+                or getattr(o, "new_volume", 0))

--- a/tools/Python/PyDemo/chart/features/order_tools.py
+++ b/tools/Python/PyDemo/chart/features/order_tools.py
@@ -1,0 +1,267 @@
+"""Phase 3 custom-JS order interactions.
+
+Adds, via injected JavaScript and the ``window.callbackFunction`` bridge:
+
+* **Crosshair tracking** - stores the price/time under the cursor in
+  ``window.__pyc`` (JS-only; not emitted to Python to avoid flooding the queue).
+* **Right-click context menu** - Buy / Sell limit at the crosshair price, and
+  "Cancel nearest order"; selections call back into Python.
+* **Drag-to-place** - in drag mode, press-and-release on the chart places a
+  limit order at the release price.
+* **Click-to-place** - in order mode, a left click (native ``events.click``)
+  places a limit order at the clicked price.
+
+All order actions route through the callback bridge to ``client.submit_order`` /
+``client.pull_order``. Buy vs sell is inferred from the price relative to the
+last trade (below = buy, above = sell).
+"""
+
+from __future__ import annotations
+
+import logging
+
+log = logging.getLogger("pydemo.chart.order_tools")
+
+# JS injected once on load. `CID` is replaced with the chart's JS object name.
+# Braces are literal JS (this is a plain string, not an f-string).
+_JS = r"""
+(function () {
+  if (window.__pydemoTools) return;
+  window.__pydemoTools = true;
+  window.__pydemoDragMode = false;
+  var C = CID;
+
+  // --- crosshair tracking (JS-only) ---
+  C.chart.subscribeCrosshairMove(function (param) {
+    if (param && param.point) {
+      var price = C.series.coordinateToPrice(param.point.y);
+      var t = C.chart.timeScale().coordinateToTime(param.point.x);
+      if (price !== undefined && price !== null) {
+        window.__pyc = { price: price, time: t };
+      }
+    }
+  });
+
+  // --- right-click context menu ---
+  var menu = document.createElement('div');
+  menu.style.cssText = 'position:fixed;z-index:99999;display:none;background:#222;'
+    + 'border:1px solid #555;border-radius:4px;font:12px sans-serif;color:#eee;'
+    + 'box-shadow:0 2px 8px rgba(0,0,0,.5);user-select:none;';
+  document.body.appendChild(menu);
+
+  function addItem(label, onClick) {
+    var d = document.createElement('div');
+    d.textContent = label;
+    d.style.cssText = 'padding:6px 14px;cursor:pointer;white-space:nowrap;';
+    d.onmouseenter = function () { d.style.background = '#3a3a3a'; };
+    d.onmouseleave = function () { d.style.background = 'transparent'; };
+    d.onclick = function () { menu.style.display = 'none'; onClick(); };
+    menu.appendChild(d);
+  }
+
+  function sep() {
+    var d = document.createElement('div');
+    d.style.cssText = 'border-top:1px solid #444;margin:2px 0;';
+    menu.appendChild(d);
+  }
+
+  function buildMenu(price) {
+    menu.innerHTML = '';
+    var p = Math.round(price * 1e6) / 1e6;
+    addItem('Buy limit @ ' + p, function () {
+      window.callbackFunction('pydemoCtx_~_buy;;;' + price);
+    });
+    addItem('Sell limit @ ' + p, function () {
+      window.callbackFunction('pydemoCtx_~_sell;;;' + price);
+    });
+    addItem('Cancel nearest order', function () {
+      window.callbackFunction('pydemoCtx_~_cancel;;;' + price);
+    });
+    sep();
+    addItem('Click-to-place: ' + (window.__pydemoClick ? 'ON' : 'OFF'), function () {
+      window.callbackFunction('pydemoMode_~_click');
+    });
+    addItem('Drag-to-place: ' + (window.__pydemoDragMode ? 'ON' : 'OFF'), function () {
+      window.callbackFunction('pydemoMode_~_drag');
+    });
+    // --- indicator on/off toggles (seeded from Python) ---
+    var inds = window.__pydemoIndSpecs || [];
+    var indState = window.__pydemoInd || {};
+    if (inds.length) {
+      sep();
+      for (var i = 0; i < inds.length; i++) {
+        (function (spec) {
+          addItem(spec.label + ': ' + (indState[spec.key] ? 'ON' : 'OFF'), function () {
+            window.callbackFunction('pydemoInd_~_' + spec.key);
+          });
+        })(inds[i]);
+      }
+    }
+  }
+
+  document.addEventListener('contextmenu', function (e) {
+    if (!window.__pyc || window.__pyc.price == null) return;
+    e.preventDefault();
+    buildMenu(window.__pyc.price);
+    menu.style.left = e.clientX + 'px';
+    menu.style.top = e.clientY + 'px';
+    menu.style.display = 'block';
+  });
+  document.addEventListener('click', function () { menu.style.display = 'none'; });
+
+  // --- drag-to-place ---
+  var dragStart = null;
+  document.addEventListener('mousedown', function (e) {
+    if (!window.__pydemoDragMode || e.button !== 0 || !window.__pyc) return;
+    dragStart = window.__pyc.price;
+  });
+  document.addEventListener('mouseup', function () {
+    if (!window.__pydemoDragMode || dragStart == null) return;
+    var end = window.__pyc ? window.__pyc.price : null;
+    var start = dragStart;
+    dragStart = null;
+    if (end != null) {
+      window.callbackFunction('pydemoDrag_~_' + start + ';;;' + end);
+    }
+  });
+})();
+"""
+
+
+class OrderTools:
+    def __init__(self, chart, bridge, client, *, order_provider,
+                 last_price_provider, default_volume: int = 1,
+                 indicators=None) -> None:
+        self._chart = chart
+        self._bridge = bridge
+        self._client = client
+        self._order_provider = order_provider        # () -> {uid: price}
+        self._last_price_provider = last_price_provider  # () -> float | None
+        self._default_volume = default_volume
+        self._indicators = indicators                # Indicators feature (toggles)
+        self._click_mode = False
+        self._drag_mode = False
+
+    # ------------------------------------------------------------------
+    # Install (called before show; scripts queue and run on load)
+    # ------------------------------------------------------------------
+
+    def install(self) -> None:
+        win = self._chart.win
+        win.handlers["pydemoCtx"] = self._bridge.guard(self._on_context_action)
+        win.handlers["pydemoDrag"] = self._bridge.guard(self._on_drag)
+        win.handlers["pydemoMode"] = self._bridge.guard(self._on_mode)
+        win.handlers["pydemoInd"] = self._bridge.guard(self._on_indicator_toggle)
+        try:
+            self._chart.run_script(_JS.replace("CID", self._chart.id))
+            self._seed_indicator_menu()
+        except Exception:  # noqa: BLE001
+            log.exception("failed to inject order-tools JS")
+
+    def _seed_indicator_menu(self) -> None:
+        """Push the indicator specs + current on/off state to JS so the context
+        menu can render a toggle per indicator."""
+        if self._indicators is None:
+            return
+        import json
+        specs = self._indicators.specs_for_menu()
+        state = {s["key"]: self._indicators.is_visible(s["key"]) for s in specs}
+        try:
+            self._chart.run_script(
+                f"window.__pydemoIndSpecs = {json.dumps(specs)};"
+                f"window.__pydemoInd = {json.dumps(state)};")
+        except Exception:  # noqa: BLE001
+            log.exception("failed to seed indicator menu")
+
+    # ------------------------------------------------------------------
+    # Mode toggles
+    # ------------------------------------------------------------------
+
+    def set_drag_mode(self, enabled: bool) -> None:
+        self._drag_mode = enabled
+        try:
+            self._chart.run_script(
+                f"window.__pydemoDragMode = {'true' if enabled else 'false'}")
+        except Exception:  # noqa: BLE001
+            log.exception("failed to set drag mode")
+
+    def set_click_mode(self, enabled: bool) -> None:
+        self._click_mode = enabled
+        try:
+            self._chart.run_script(
+                f"window.__pydemoClick = {'true' if enabled else 'false'}")
+        except Exception:  # noqa: BLE001
+            log.exception("failed to set click mode")
+
+    def _on_mode(self, which) -> None:
+        """Context-menu toggle for click/drag placement modes."""
+        if which == "click":
+            self.set_click_mode(not self._click_mode)
+        elif which == "drag":
+            self.set_drag_mode(not self._drag_mode)
+
+    def on_click(self, chart, time, price) -> None:
+        """Wired to native chart.events.click; places on left click in order mode."""
+        if not self._click_mode or price is None:
+            return
+        self._place_limit(float(price))
+
+    # ------------------------------------------------------------------
+    # JS callbacks
+    # ------------------------------------------------------------------
+
+    def _on_context_action(self, action, price) -> None:
+        price = float(price)
+        if action == "buy":
+            self._submit("buy", price)
+        elif action == "sell":
+            self._submit("sell", price)
+        elif action == "cancel":
+            self._cancel_nearest(price)
+
+    def _on_drag(self, start, end) -> None:
+        # Entry is the release price; start is informational.
+        self._place_limit(float(end))
+
+    def _on_indicator_toggle(self, key) -> None:
+        """Context-menu toggle: flip one indicator on/off and reflect the new
+        state back to JS so the menu label updates next time it opens."""
+        if self._indicators is None:
+            return
+        new_state = not self._indicators.is_visible(key)
+        self._indicators.set_visible(key, new_state)
+        try:
+            self._chart.run_script(
+                f"window.__pydemoInd['{key}'] = {'true' if new_state else 'false'};")
+        except Exception:  # noqa: BLE001
+            log.exception("failed to push indicator state for %s", key)
+
+    # ------------------------------------------------------------------
+    # Order helpers
+    # ------------------------------------------------------------------
+
+    def _place_limit(self, price: float) -> None:
+        side = self._infer_side(price)
+        self._submit(side, price)
+
+    def _infer_side(self, price: float) -> str:
+        last = self._last_price_provider()
+        # Resting buy limits sit below the market, sell limits above.
+        if last is not None and price > last:
+            return "sell"
+        return "buy"
+
+    def _submit(self, side: str, price: float) -> None:
+        vol = self._default_volume
+        self._bridge.run_coro(
+            lambda: self._client.submit_order(side, vol, price, "limit"))
+        log.info("chart order: %s %s @ %s", side, vol, price)
+
+    def _cancel_nearest(self, price: float) -> None:
+        orders = self._order_provider() or {}
+        if not orders:
+            log.info("cancel nearest: no working orders")
+            return
+        uid = min(orders, key=lambda u: abs(orders[u] - price))
+        self._bridge.run_coro(lambda: self._client.pull_order(uid))
+        log.info("chart cancel nearest order %s (near %s)", uid, price)

--- a/tools/Python/PyDemo/chart/features/position_line.py
+++ b/tools/Python/PyDemo/chart/features/position_line.py
@@ -1,0 +1,76 @@
+"""Net-position / average-fill overlay line.
+
+A single solid horizontal line at the position's average open price, labeled
+with the net position. Hidden when flat. Like order lines, it must be recreated
+after a ``chart.set()`` (which wipes drawings), so it exposes both an event-
+driven :meth:`update` and a post-``set`` :meth:`rebuild`.
+"""
+
+from __future__ import annotations
+
+import logging
+
+log = logging.getLogger("pydemo.chart.position_line")
+
+
+class PositionLine:
+    def __init__(self, chart) -> None:
+        self._chart = chart
+        self._line = None
+        self._state = None  # {price, net} or None when flat
+        self._market_id = None
+
+    def set_market(self, market_id) -> None:
+        if market_id != self._market_id:
+            self._market_id = market_id
+            self._state = None
+            self._delete()
+
+    def update(self, positions, market_id) -> None:
+        """Refresh from the account 'positions' event (list of dicts)."""
+        self._market_id = market_id
+        state = None
+        for pos in positions:
+            if pos.get("market_id") != market_id:
+                continue
+            net = pos.get("net")
+            if net is None:
+                net = pos.get("buys", 0) - pos.get("sells", 0)
+            avg = pos.get("average_open_price")
+            if net and avg not in (None, "", "0"):
+                try:
+                    state = {"price": float(avg), "net": int(net)}
+                except (ValueError, TypeError):
+                    state = None
+            break
+        self._state = state
+        self._delete()
+        self._create()
+
+    def rebuild(self) -> None:
+        """Recreate the line after a chart.set() wiped it."""
+        self._line = None
+        self._create()
+
+    # ------------------------------------------------------------------
+
+    def _create(self) -> None:
+        if not self._state:
+            return
+        net = self._state["net"]
+        color = "#26a69a" if net > 0 else "#ef5350"
+        text = f"POS {net:+d} @ {self._state['price']}"
+        try:
+            self._line = self._chart.horizontal_line(
+                self._state["price"], color=color, width=2, style="solid",
+                text=text)
+        except Exception:  # noqa: BLE001
+            log.exception("failed to draw position line")
+
+    def _delete(self) -> None:
+        if self._line is not None:
+            try:
+                self._line.delete()
+            except Exception:  # noqa: BLE001
+                pass
+            self._line = None

--- a/tools/Python/PyDemo/chart/history.py
+++ b/tools/Python/PyDemo/chart/history.py
@@ -1,0 +1,239 @@
+"""Historical bar loading via the T4 chart API (``t4login.ChartClient``).
+
+Binary-first (``/chart/barchart`` with ``application/octet-stream``, decoded by
+``ChartDataStreamReaderAggr``), falling back to JSON if the binary request fails
+or yields no bars. Both paths return the chart's normalised bar dicts
+(``{time: datetime, open, high, low, close, volume}``) and the path that served
+the data is logged.
+
+The JSON fallback mirrors JSDemo's ``calibrateScale`` trick: JSON bar prices may
+be unscaled integers, so when a live reference price is available we infer the
+power-of-ten divisor from ``rawClose / livePrice``.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from datetime import datetime
+from typing import Any, Optional
+
+from t4login.client.chart_client import ChartClient
+
+from . import convert
+
+log = logging.getLogger("pydemo.chart.history")
+
+# chart interval (seconds) -> (T4 barInterval name, barPeriod)
+_INTERVAL_MAP: dict[int, tuple[str, int]] = {
+    15: ("Second", 15),
+    30: ("Second", 30),
+    60: ("Minute", 1),
+    300: ("Minute", 5),
+    900: ("Minute", 15),
+    3600: ("Hour", 1),
+    86400: ("Day", 1),
+}
+
+
+def interval_to_t4(interval_seconds: int) -> tuple[str, int]:
+    """Map a chart interval in seconds to T4 ``(barInterval, barPeriod)``."""
+    if interval_seconds in _INTERVAL_MAP:
+        return _INTERVAL_MAP[interval_seconds]
+    # Derive a sensible (unit, period) for intervals not in the table.
+    if interval_seconds % 86400 == 0:
+        return ("Day", interval_seconds // 86400)
+    if interval_seconds % 3600 == 0:
+        return ("Hour", interval_seconds // 3600)
+    if interval_seconds % 60 == 0:
+        return ("Minute", interval_seconds // 60)
+    return ("Second", max(1, interval_seconds))
+
+
+def calibrate_scale(raw_close: float, live_price: float) -> Optional[float]:
+    """Infer a power-of-ten divisor from a raw JSON close vs a live price.
+
+    Returns ``None`` when the ratio is not a plausible power of ten (exponent
+    outside ``0..8``), matching the JS plausibility guard.
+    """
+    if not raw_close or not live_price:
+        return None
+    try:
+        ratio = float(raw_close) / float(live_price)
+    except (ZeroDivisionError, ValueError):
+        return None
+    if ratio <= 0:
+        return None
+    exp = round(math.log10(ratio))
+    if exp < 0 or exp > 8:
+        return None
+    return float(10 ** exp)
+
+
+class _BarCollector:
+    """``ChartDataHandler`` implementation that gathers decoded bars."""
+
+    def __init__(self, tz_offset_hours: float = 0.0) -> None:
+        self.bars: list[dict] = []
+        self.market_definition: Any = None
+        self._tz = tz_offset_hours
+
+    def on_market_definition(self, market_definition: Any) -> None:
+        self.market_definition = market_definition
+
+    def on_bar(self, bar: Any) -> None:
+        self.bars.append(convert.bar_to_dict(bar, self._tz))
+
+    # Events we don't render on the price chart (no-ops).
+    def on_mode_change(self, *args: Any, **kwargs: Any) -> None:  # noqa: D401
+        pass
+
+    def on_settlement(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+    def on_open_interest(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+
+class ChartHistory:
+    """Fetches and normalises historical bars for the chart."""
+
+    def __init__(self, token: str, *, base_url: Optional[str] = None,
+                 tz_offset_hours: float = 0.0) -> None:
+        kwargs: dict[str, Any] = {}
+        if base_url:
+            kwargs["base_url"] = base_url
+        self._client = ChartClient(token, **kwargs)
+        self._tz = tz_offset_hours
+
+    def close(self) -> None:
+        self._client.close()
+
+    def fetch(
+        self,
+        *,
+        exchange_id: str,
+        contract_id: str,
+        market_id: Optional[str],
+        interval_seconds: int,
+        trade_date_start: str,
+        trade_date_end: str,
+        live_price: Optional[float] = None,
+        continuation_type: Optional[str] = None,
+    ) -> tuple[list[dict], str]:
+        """Return ``(bars, source)`` where ``source`` is ``"binary"`` or ``"json"``.
+
+        Tries binary first; on any error or empty result, falls back to JSON.
+        Bars are sorted ascending by time. ``continuation_type`` (e.g. ``"Volume"``)
+        requests a continuous, roll-stitched futures series; omit it for cash/ETF
+        contracts or a single futures month.
+        """
+        bar_interval, bar_period = interval_to_t4(interval_seconds)
+        common = dict(
+            exchange_id=exchange_id,
+            contract_id=contract_id,
+            market_id=market_id,
+            bar_interval=bar_interval,
+            bar_period=bar_period,
+            trade_date_start=trade_date_start,
+            trade_date_end=trade_date_end,
+        )
+        if continuation_type:
+            common["continuation_type"] = continuation_type
+
+        # --- binary (preferred) -------------------------------------------
+        try:
+            collector = _BarCollector(self._tz)
+            self._client.get_barchart_binary(handler=collector, **common)
+            if collector.bars:
+                bars = sorted(collector.bars, key=lambda b: b["time"])
+                log.info("history: %d bars via BINARY (%s/%s %s)",
+                         len(bars), exchange_id, contract_id, bar_interval)
+                return bars, "binary"
+            log.warning("history: binary returned 0 bars; trying JSON")
+        except Exception as exc:  # noqa: BLE001 - fall back on any failure
+            log.warning("history: binary failed (%s); trying JSON", exc)
+
+        # --- JSON fallback -------------------------------------------------
+        try:
+            raw = self._client.get_barchart_json(**common)
+            bars = self._parse_json_bars(raw, live_price)
+            bars.sort(key=lambda b: b["time"])
+            log.info("history: %d bars via JSON (%s/%s %s)",
+                     len(bars), exchange_id, contract_id, bar_interval)
+            return bars, "json"
+        except Exception as exc:  # noqa: BLE001
+            log.error("history: JSON fallback failed (%s)", exc)
+            return [], "none"
+
+    # ------------------------------------------------------------------
+
+    def _parse_json_bars(self, raw: Any, live_price: Optional[float]) -> list[dict]:
+        rows = self._extract_rows(raw)
+        if not rows:
+            return []
+
+        # Determine price scale once using the most recent raw close.
+        scale = 1.0
+        if live_price:
+            last_close = self._field(rows[-1], ("closePrice", "close", "c"))
+            cal = calibrate_scale(self._to_float(last_close), live_price)
+            if cal:
+                scale = cal
+
+        bars: list[dict] = []
+        for row in rows:
+            t = self._parse_time(self._field(row, ("time", "barTime", "t")))
+            if t is None:
+                continue
+            bars.append({
+                "time": t,
+                "open": self._to_float(self._field(row, ("openPrice", "open", "o"))) / scale,
+                "high": self._to_float(self._field(row, ("highPrice", "high", "h"))) / scale,
+                "low": self._to_float(self._field(row, ("lowPrice", "low", "l"))) / scale,
+                "close": self._to_float(self._field(row, ("closePrice", "close", "c"))) / scale,
+                "volume": int(self._to_float(self._field(row, ("volume", "v"))) or 0),
+            })
+        return bars
+
+    @staticmethod
+    def _extract_rows(raw: Any) -> list[dict]:
+        if isinstance(raw, list):
+            return raw
+        if isinstance(raw, dict):
+            for key in ("bars", "barchart", "barChart", "data", "results"):
+                val = raw.get(key)
+                if isinstance(val, list):
+                    return val
+        return []
+
+    @staticmethod
+    def _field(row: dict, names: tuple[str, ...]) -> Any:
+        for n in names:
+            if n in row:
+                return row[n]
+        return None
+
+    @staticmethod
+    def _to_float(value: Any) -> float:
+        if value is None:
+            return 0.0
+        try:
+            return float(value)
+        except (ValueError, TypeError):
+            return 0.0
+
+    @staticmethod
+    def _parse_time(value: Any) -> Optional[datetime]:
+        if value is None:
+            return None
+        if isinstance(value, (int, float)):
+            # Epoch seconds.
+            from datetime import timezone
+            return datetime.fromtimestamp(float(value), tz=timezone.utc)
+        try:
+            # ISO 'YYYY-MM-DDTHH:mm:ss' (exchange wall-clock); keep as UTC.
+            from datetime import timezone
+            return datetime.fromisoformat(str(value)).replace(tzinfo=timezone.utc)
+        except ValueError:
+            return None

--- a/tools/Python/PyDemo/config/config.template.yaml
+++ b/tools/Python/PyDemo/config/config.template.yaml
@@ -17,3 +17,32 @@ websocket:
 
   ##optional
   priceFormat: 2
+
+# Companion chart window (TradingView Lightweight Charts). All keys optional.
+chart:
+  enabled: true            # set false to disable the chart window
+  interval_seconds: 60     # default candle interval (15, 60, 300, 900)
+  initial_load_days: 2     # minimum days of history to load (floor)
+  target_bars: 500         # aim for ~this many bars per interval — the load
+                           # window scales with the interval so higher intervals
+                           # don't look truncated (e.g. 15m loads ~6 days, not 2)
+  max_load_days: 120       # ceiling on the scaled INITIAL window (avoids huge fetches)
+  # Infinite scroll-back: older bars load and prepend as you scroll left.
+  chunk_days: 1            # how many days of history to fetch per scroll-back step
+  scroll_buffer_days: 1    # prefetch older bars once fewer than ~this many DAYS of
+                           # bars remain off the left edge. Scales with the interval
+                           # (a 1-day look-ahead at every zoom; JSDemo parity), so
+                           # older bars are loaded before you scroll to them.
+  history_floor: "2000-01-01"  # stop paging older history at this date (ISO)
+  tz_offset_hours: 0       # shift historical bars if they appear time-offset
+                           # from live candles (exchange tz vs UTC calibration)
+
+# Portfolio Study viewer (walk-forward rotation backtest). Runs on the live T4
+# futures basket (ES/NQ/YM/RTY) over the From/To window; requires a T4 login.
+# All keys optional — they prefill the form.
+portfolio_study:
+  lookback_days: 550       # From defaults to today-lookback_days (To = today).
+                           # Needs > warmup(252)+retune(10) trading days (~13 mo);
+                           # 550 calendar days clears that comfortably.
+  start: ''                # explicit From (YYYY-MM-DD); blank = use lookback_days
+  end: ''                  # explicit To   (YYYY-MM-DD); blank = today

--- a/tools/Python/PyDemo/main.py
+++ b/tools/Python/PyDemo/main.py
@@ -2,6 +2,7 @@ import asyncio
 import websockets
 import yaml
 import os
+import logging
 from T4APIClient import Client
 from t4_gui import T4_GUI
 import tkinter as tk
@@ -22,11 +23,17 @@ def load_config(path="config\\config.yaml"):
         return yaml.safe_load(file)
 
 async def main():
+    logging.basicConfig(level=logging.INFO,
+                        format="%(asctime)s %(name)s %(levelname)s %(message)s")
     config = load_config()
     client = Client(config)
 
     root = tk.Tk()
-    app = T4_GUI(root, client)
+    loop = asyncio.get_running_loop()
+    # The chart is no longer launched at startup; it opens on demand via the
+    # "Chart" button (see t4_gui.T4_GUI.open_chart). The GUI needs the loop to
+    # schedule the chart window's async run() when that button is clicked.
+    app = T4_GUI(root, client, loop)
 
     async def tkinter_loop():
         while True:

--- a/tools/Python/PyDemo/requirements.txt
+++ b/tools/Python/PyDemo/requirements.txt
@@ -2,3 +2,20 @@ httpx>=0.28.1
 websockets>=15.0.1
 pyyaml>=6.0.2
 protobuf>=6.31.1
+
+# Chart (companion TradingView Lightweight Charts window)
+lightweight-charts>=2.0
+pywebview>=5.0
+pandas>=2.0
+
+# Portfolio Study viewer (walk-forward rotation results) embeds an equity chart.
+matplotlib>=3.7
+
+# The chart's historical-bar decoder lives in the sibling t4-Python-api package.
+# Install it in editable mode (it has its own pyproject.toml):
+#   pip install -e ../t4-Python-api
+#
+# The Portfolio Study feature shells out to the sibling research package
+# (tools/Python/algo-py). Its compute deps (numpy/pandas + the decoder package)
+# must be importable by the interpreter that runs PyDemo. From algo-py:
+#   pip install -r requirements.txt   (and  pip install -e ../t4-Python-api)

--- a/tools/Python/PyDemo/study/__init__.py
+++ b/tools/Python/PyDemo/study/__init__.py
@@ -1,0 +1,11 @@
+"""PyDemo Portfolio Study feature.
+
+A launcher + results viewer for the walk-forward rotation backtest that lives in
+the sibling ``algo-py/research`` package. PyDemo does NOT reimplement the
+algorithm: it shells out to ``research.run_portfolio_study --json`` (the same
+way JSDemo's server does), reads the JSON result, and renders it in a Tkinter
+window with an embedded matplotlib equity curve.
+
+(The single-instrument Backtester is a separate, self-contained JSDemo port that
+runs in-process on T4 bars — see the sibling ``backtest/`` package.)
+"""

--- a/tools/Python/PyDemo/study/runner.py
+++ b/tools/Python/PyDemo/study/runner.py
@@ -1,0 +1,200 @@
+"""study/runner.py
+
+Run the walk-forward portfolio rotation backtest by shelling out to the existing
+``research.run_portfolio_study`` module (in the sibling ``algo-py`` package) with
+its ``--json`` mode, then return the parsed result dict.
+
+This mirrors JSDemo's ``server.js::handlePortfolioStudy`` — we reuse the tested
+Python pipeline verbatim (fetch -> walk-forward re-tune -> multi-asset OOS
+backtest -> JSON) rather than duplicating any of it. The subprocess keeps the
+research package's heavy deps (numpy/pandas) isolated from PyDemo's interpreter
+state and avoids any sys.path surgery.
+
+The study runs on the live T4 **futures** basket (ES/NQ/YM/RTY) over a chosen date
+window by default; the CSV/ETF path is still supported via ``source="csv"`` for the
+research CLI but is no longer surfaced in PyDemo's study window.
+
+``run_study`` is BLOCKING (a run takes several minutes — the walk-forward is
+CPU-bound) — call it from a worker thread, never on the Tk/asyncio main thread.
+"""
+
+from __future__ import annotations
+
+import collections
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from typing import Callable, Optional
+
+from . import t4_fetch
+
+# PyDemo/study/ -> PyDemo/ -> Python/ -> Python/algo-py
+_BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+ALGO_PY_DIR = os.path.normpath(os.path.join(_BASE_DIR, "..", "..", "algo-py"))
+
+
+class StudyError(RuntimeError):
+    """Raised when the study subprocess fails or returns no/invalid JSON."""
+
+
+def default_csv_dir() -> str:
+    """The research package's bundled CSV directory (spy.csv/qqq.csv/...)."""
+    return os.path.join(ALGO_PY_DIR, "research", "data_csv")
+
+
+def run_study(basket: str = "futures", source: str = "t4",
+              csv_dir: str | None = None, token: str | None = None,
+              client=None, start: str | None = None, end: str | None = None,
+              timeout: float = 600.0,
+              on_line: Optional[Callable[[str], None]] = None) -> dict:
+    """Run the portfolio study and return its JSON result dict.
+
+    For source='t4' the futures bars are fetched IN THIS PROCESS via
+    ``study.t4_fetch`` (which reuses the chart's binary→JSON ChartHistory path),
+    written to a temp dir of per-key CSVs, and handed to the study through its
+    reliable ``--source csv`` path — so the subprocess never touches T4 directly.
+
+    Args:
+        basket: 'futures' (ES/NQ/YM/RTY, the default for the live T4 path) or
+            'etf' (SPY/QQQ/DIA/IWM, CSV path).
+        source: 't4' (live T4 daily bars, fetched in-process, the default) or
+            'csv' (reads per-key OHLCV files; research CLI fallback).
+        csv_dir: directory of per-key CSVs (csv source). Defaults to the research
+            package's bundled data_csv dir.
+        token: unused legacy arg (kept for back-compat); the t4 path uses `client`.
+        client: the live T4APIClient — required for source='t4' (provides apiUrl,
+            jw_token, config for the in-process fetch).
+        start: fetch window start (YYYY-MM-DD). Forwarded as --start. When unset the
+            research config default window is used.
+        end: fetch window end (YYYY-MM-DD). Forwarded as --end.
+        timeout: hard cap on the subprocess (seconds).
+        on_line: optional callback invoked with each line the subprocess prints
+            (the research scripts emit progress to stdout — '[portfolio] …'). The
+            run is slow (several minutes), so this is how the UI shows it's alive.
+            Called on the calling thread; keep it cheap and thread-safe.
+
+    Returns:
+        The dict written by research.result_json.to_result_dict (equity[],
+        baseline_equity[], stats{}, params_log[], holdings{}, meta{}, config{}, ...).
+
+    Raises:
+        StudyError: on a non-zero exit, timeout, or unreadable/non-ok JSON.
+    """
+    if not os.path.isdir(ALGO_PY_DIR):
+        raise StudyError(
+            f"algo-py package not found at {ALGO_PY_DIR} — the research code must "
+            "be a sibling of PyDemo for the study to run."
+        )
+
+    tmp_csv_dir = None
+    try:
+        # T4 source: fetch the futures bars in-process (the proven binary→JSON
+        # ChartHistory path) into a temp dir of per-key CSVs, then run the study
+        # over them via the reliable CSV path. The subprocess never touches T4.
+        run_source, run_csv_dir = source, csv_dir
+        keys: list[str] | None = None
+        if source == "t4":
+            if client is None:
+                raise StudyError("Internal error: the T4 study needs a live client.")
+            tmp_csv_dir = tempfile.mkdtemp(prefix="pydemo_study_t4_")
+            try:
+                fetched = t4_fetch.fetch_futures_csvs(client, start or "", end or "",
+                                                      tmp_csv_dir, on_line=on_line)
+            except t4_fetch.FetchError as exc:
+                raise StudyError(str(exc)) from exc
+            # Run on exactly the instruments that returned data (some may be dropped,
+            # e.g. YM on a feed without the Dow), so the basket matches the CSVs.
+            keys = [k for k, _ in fetched]
+            run_source, run_csv_dir = "csv", tmp_csv_dir
+
+        # Write the result to a temp file the subprocess owns, then read it back.
+        fd, out_path = tempfile.mkstemp(prefix="pydemo_study_", suffix=".json")
+        os.close(fd)
+
+        argv = [
+            sys.executable, "-m", "research.run_portfolio_study",
+            "--json", out_path,
+            "--source", run_source,
+            "--basket", basket,
+        ]
+        if run_source == "csv":
+            argv += ["--csv-dir", run_csv_dir or default_csv_dir()]
+        if keys:
+            argv += ["--keys", ",".join(keys)]
+        if start:
+            argv += ["--start", start]
+        if end:
+            argv += ["--end", end]
+
+        return _run_json_subprocess(argv, out_path, timeout, env=None, on_line=on_line)
+    finally:
+        if tmp_csv_dir:
+            shutil.rmtree(tmp_csv_dir, ignore_errors=True)
+
+
+def _run_json_subprocess(argv: list[str], out_path: str, timeout: float,
+                         env: dict | None = None,
+                         on_line: Optional[Callable[[str], None]] = None) -> dict:
+    """Run a research --json subprocess, read its temp-file result, return the dict.
+
+    Streams the subprocess's combined stdout/stderr line by line so the UI can
+    show progress (the research scripts print '[portfolio] …' steps and actionable
+    errors — bad CSV dir, missing token, too few bars). We keep the tail of those
+    lines to surface a meaningful message on failure.
+    """
+    # stderr -> stdout so a single reader sees everything in order; bufsize=1 +
+    # text mode gives line-buffered reads.
+    proc = subprocess.Popen(
+        argv, cwd=ALGO_PY_DIR, env=env,
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+        text=True, bufsize=1,
+    )
+    tail = collections.deque(maxlen=20)
+    deadline = time.monotonic() + timeout
+    try:
+        for line in proc.stdout:
+            line = line.rstrip()
+            if line:
+                tail.append(line)
+                if on_line is not None:
+                    try:
+                        on_line(line)
+                    except Exception:  # noqa: BLE001 - progress is best-effort
+                        pass
+            if time.monotonic() > deadline:
+                proc.kill()
+                _safe_unlink(out_path)
+                raise StudyError(f"Run timed out after {timeout:.0f}s")
+        returncode = proc.wait()
+    finally:
+        if proc.stdout:
+            proc.stdout.close()
+
+    if returncode != 0:
+        _safe_unlink(out_path)
+        msg = tail[-1] if tail else f"exit code {returncode}"
+        raise StudyError(msg)
+
+    try:
+        with open(out_path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise StudyError(f"Could not read run output: {exc}") from exc
+    finally:
+        _safe_unlink(out_path)
+
+    if not isinstance(data, dict) or not data.get("ok"):
+        raise StudyError(data.get("error", "Run returned no result")
+                         if isinstance(data, dict) else "Run returned no result")
+    return data
+
+
+def _safe_unlink(path: str) -> None:
+    try:
+        os.unlink(path)
+    except OSError:
+        pass

--- a/tools/Python/PyDemo/study/study_window.py
+++ b/tools/Python/PyDemo/study/study_window.py
@@ -1,0 +1,333 @@
+"""study/study_window.py
+
+Tkinter results viewer for the walk-forward portfolio rotation backtest.
+
+Shows a run form (basket / source / CSV dir / Run), an embedded matplotlib equity
+curve (rotation vs equal-weight buy & hold), a stats grid, and a re-tune log
+table. The backtest itself runs in ``study.runner.run_study`` on a worker thread
+so PyDemo's tkinter/asyncio loop and price chart stay responsive; results are
+marshalled back onto the Tk thread via ``after()`` (tkinter is not thread-safe —
+never draw from the worker).
+
+Layout/labels mirror JSDemo's algo/ui/PortfolioStudyPanel.js so the two front
+ends stay consistent. Importing this module requires matplotlib; callers should
+guard the import (see t4_gui) so a missing dep disables the feature gracefully.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import queue
+import threading
+import tkinter as tk
+from tkinter import ttk
+
+from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
+from matplotlib.figure import Figure
+
+from . import runner
+
+
+# --- formatting helpers (mirror PortfolioStudyPanel.js) ----------------------
+def _fmt_money(v) -> str:
+    return "—" if v is None else f"${float(v):,.0f}"
+
+
+def _fmt_pct(v) -> str:
+    return "—" if v is None else f"{float(v):.2f}%"
+
+
+def _fmt_num(v) -> str:
+    return "—" if v is None else f"{float(v):.2f}"
+
+
+def _iso_day(unix_sec) -> str:
+    if unix_sec is None:
+        return "—"
+    return _dt.datetime.utcfromtimestamp(int(unix_sec)).strftime("%Y-%m-%d")
+
+
+class PortfolioStudyWindow(tk.Toplevel):
+    def __init__(self, parent, client=None):
+        super().__init__(parent)
+        self.client = client
+        self.title("Portfolio Study — walk-forward rotation")
+        self.geometry("820x720")
+        self.configure(bg="white")
+        self._running = False
+        self._elapsed = 0
+        self._elapsed_after = None
+        # Worker results are marshalled back to the Tk thread through this queue
+        # and drained by a main-thread poller; never touch tkinter from _worker.
+        self._result_q = queue.Queue()
+        self._build()
+
+    # -- UI construction -------------------------------------------------------
+    def _build(self):
+        form = tk.Frame(self, bg="white", padx=16, pady=12)
+        form.pack(fill="x")
+
+        tk.Label(form, text="Basket: ES/NQ/YM/RTY (futures) · Source: live T4",
+                 bg="white", fg="#555").grid(row=0, column=0, columnspan=4, sticky="w")
+
+        tk.Label(form, text="From:", bg="white").grid(row=1, column=0, sticky="w", pady=(8, 0))
+        self.start = tk.Entry(form, width=14)
+        self.start.grid(row=1, column=1, sticky="w", padx=(4, 16), pady=(8, 0))
+        tk.Label(form, text="To:", bg="white").grid(row=1, column=2, sticky="w", pady=(8, 0))
+        self.end = tk.Entry(form, width=14)
+        self.end.grid(row=1, column=3, sticky="w", padx=(4, 16), pady=(8, 0))
+
+        self.run_btn = tk.Button(form, text="Run Study", bg="#3b82f6", fg="white",
+                                 command=self._run)
+        self.run_btn.grid(row=0, column=4, rowspan=2, padx=(8, 0))
+
+        self.status = tk.Label(self, text="", bg="white", fg="#555", anchor="w")
+        self.status.pack(fill="x", padx=16)
+
+        # Indeterminate progress bar — the run is slow (several minutes), so this
+        # plus the streamed status lines make it obvious the study is alive.
+        self.progress = ttk.Progressbar(self, mode="indeterminate")
+        self.progress.pack(fill="x", padx=16, pady=(2, 0))
+
+        note = tk.Label(
+            self, bg="white", fg="#777", justify="left", anchor="w", wraplength=780,
+            text=("Runs the walk-forward rotation on the ES/NQ/YM/RTY futures basket "
+                  "using live T4 daily bars over the From/To window, and shows the "
+                  "out-of-sample equity vs an equal-weight buy & hold. Instruments your "
+                  "feed doesn't carry (e.g. YM on some sims) are skipped automatically. "
+                  "Requires a T4 login. The window needs ~13+ months so the walk-forward "
+                  "has enough history. A run takes several minutes — progress is shown above."),
+        )
+        note.pack(fill="x", padx=16, pady=(2, 8))
+
+        # Equity chart (embedded matplotlib).
+        self.fig = Figure(figsize=(7.6, 3.0), dpi=100)
+        self.ax = self.fig.add_subplot(111)
+        self.ax.set_title("Equity — rotation (blue) vs equal-weight buy & hold (red)",
+                          fontsize=9)
+        self.fig.tight_layout()
+        self.canvas = FigureCanvasTkAgg(self.fig, master=self)
+        self.canvas.get_tk_widget().pack(fill="both", expand=False, padx=16)
+
+        # Stats grid.
+        self.stats_frame = tk.Frame(self, bg="white", padx=16, pady=8)
+        self.stats_frame.pack(fill="x")
+
+        # Re-tune log table.
+        tk.Label(self, text='Re-tunes (the "rebuild")', bg="white",
+                 font=("Arial", 11, "bold")).pack(anchor="w", padx=16)
+        cols = ("date", "mom", "value_lb", "top_n", "objective", "switched")
+        headers = ("Date", "Mom (lookback/skip)", "Value lb", "Top N", "Objective", "Switched")
+        tree_wrap = tk.Frame(self)
+        tree_wrap.pack(fill="both", expand=True, padx=16, pady=(2, 12))
+        self.tree = ttk.Treeview(tree_wrap, columns=cols, show="headings", height=8)
+        for c, h in zip(cols, headers):
+            self.tree.heading(c, text=h)
+            self.tree.column(c, width=120, anchor="center")
+        vsb = ttk.Scrollbar(tree_wrap, orient="vertical", command=self.tree.yview)
+        self.tree.configure(yscrollcommand=vsb.set)
+        self.tree.pack(side="left", fill="both", expand=True)
+        vsb.pack(side="right", fill="y")
+
+        self._apply_prefill()
+
+    def _apply_prefill(self):
+        """Prefill the From/To window: a recent default, overridable via the optional
+        config 'portfolio_study' block ('start'/'end', or 'lookback_days').
+
+        The walk-forward needs > warmup(252) + retune(10) daily bars, so the default
+        spans ~18 months of calendar time to comfortably clear ~262 trading days.
+        """
+        cfg = {}
+        try:
+            cfg = (getattr(self.client, "config", None) or {}).get("portfolio_study", {}) or {}
+        except Exception:  # noqa: BLE001 - prefill is best-effort
+            cfg = {}
+        try:
+            lookback = int(cfg.get("lookback_days") or 550)
+        except (TypeError, ValueError):
+            lookback = 550
+        today = _dt.date.today()
+        start_default = (today - _dt.timedelta(days=lookback)).strftime("%Y-%m-%d")
+        end_default = today.strftime("%Y-%m-%d")
+        self.start.insert(0, str(cfg.get("start") or start_default))
+        self.end.insert(0, str(cfg.get("end") or end_default))
+
+    # -- run / worker ----------------------------------------------------------
+    def _run(self):
+        if self._running:
+            return
+        token = getattr(self.client, "jw_token", None)
+        if not token:
+            self._set_status("Connect/login to T4 first — the study runs on live "
+                             "T4 futures data and needs a token.", error=True)
+            return
+        try:
+            start = self._norm_date(self.start.get())
+            end = self._norm_date(self.end.get())
+        except ValueError:
+            self._set_status("From/To must be dates in 'YYYY-MM-DD' format.", error=True)
+            return
+        opts = {
+            "basket": "futures",
+            "source": "t4",
+            "client": self.client,
+            "start": start,
+            "end": end,
+        }
+        self._running = True
+        self.run_btn.config(state="disabled")
+        self._last_progress = ""
+        self.progress.start(12)
+        self._elapsed = 0
+        self._refresh_running_status()
+        self._elapsed_after = self.after(1000, self._tick_elapsed)
+        threading.Thread(target=self._worker, args=(opts,), daemon=True).start()
+        # Poll from the main (Tk) thread — after() is only safe to call here.
+        self._poll_results()
+
+    def _worker(self, opts):
+        # Runs off the Tk thread: must not call any tkinter method (including
+        # after()). Push the outcome onto the queue; the poller does the UI work.
+        try:
+            data = runner.run_study(
+                on_line=lambda ln: self._result_q.put(("progress", ln)), **opts)
+        except runner.StudyError as exc:
+            self._result_q.put(("error", str(exc)))
+            return
+        except Exception as exc:  # noqa: BLE001 - never let the worker die silently
+            self._result_q.put(("error", f"Unexpected error: {exc}"))
+            return
+        self._result_q.put(("render", data))
+
+    def _poll_results(self):
+        """Drain worker results on the Tk thread; reschedule until done.
+
+        'progress' lines just update the status; 'error'/'render' are terminal.
+        Drains everything currently queued each tick so progress stays current.
+        """
+        try:
+            while True:
+                kind, payload = self._result_q.get_nowait()
+                if kind == "progress":
+                    self._last_progress = payload
+                    self._refresh_running_status()
+                    continue
+                if kind == "error":
+                    self._on_error(payload)
+                else:
+                    self._render(payload)
+                return  # terminal message handled — stop polling
+        except queue.Empty:
+            if self._running:
+                self.after(100, self._poll_results)
+
+    def _tick_elapsed(self):
+        """Once-a-second elapsed counter while a run is in flight."""
+        if not self._running:
+            return
+        self._elapsed += 1
+        self._refresh_running_status()
+        self._elapsed_after = self.after(1000, self._tick_elapsed)
+
+    def _refresh_running_status(self):
+        base = f"Running… {self._elapsed}s (several minutes)"
+        self._set_status(f"{base} — {self._last_progress}" if self._last_progress else base)
+
+    def _stop_progress(self):
+        self._running = False
+        try:
+            self.progress.stop()
+        except Exception:  # noqa: BLE001
+            pass
+        if self._elapsed_after is not None:
+            try:
+                self.after_cancel(self._elapsed_after)
+            except Exception:  # noqa: BLE001
+                pass
+            self._elapsed_after = None
+
+    def _on_error(self, msg):
+        self._stop_progress()
+        self.run_btn.config(state="normal")
+        self._set_status(f"Failed: {msg}", error=True)
+
+    # -- rendering -------------------------------------------------------------
+    def _render(self, data):
+        self._stop_progress()
+        self.run_btn.config(state="normal")
+        try:
+            self._render_equity(data.get("equity", []), data.get("baseline_equity", []))
+            self._render_stats(data)
+            self._render_params(data.get("params_log", []))
+            meta = data.get("meta", {}) or {}
+            basket = ", ".join(meta.get("basket") or []) or "futures"
+            self._set_status(f"Done — {basket} via {meta.get('source', 't4')} "
+                             f"({meta.get('rows', '?')} bars, {meta.get('span', '')}).")
+        except Exception as exc:  # noqa: BLE001
+            self._set_status(f"Render failed: {exc}", error=True)
+
+    def _render_equity(self, equity, baseline):
+        self.ax.clear()
+        self.ax.set_title("Equity — rotation (blue) vs equal-weight buy & hold (red)",
+                          fontsize=9)
+        if equity:
+            xs = [_dt.datetime.utcfromtimestamp(p["time"]) for p in equity if p.get("value") is not None]
+            ys = [p["value"] for p in equity if p.get("value") is not None]
+            self.ax.plot(xs, ys, color="#2962ff", linewidth=1.5, label="rotation")
+        if baseline:
+            bxs = [_dt.datetime.utcfromtimestamp(p["time"]) for p in baseline if p.get("value") is not None]
+            bys = [p["value"] for p in baseline if p.get("value") is not None]
+            self.ax.plot(bxs, bys, color="#ff6b6b", linewidth=1.5, label="buy & hold")
+        self.ax.legend(loc="upper left", fontsize=8)
+        self.ax.grid(True, alpha=0.3)
+        self.fig.autofmt_xdate()
+        self.fig.tight_layout()
+        self.canvas.draw()
+
+    def _render_stats(self, data):
+        for w in self.stats_frame.winfo_children():
+            w.destroy()
+        s = data.get("stats", {}) or {}
+        cells = [
+            ("Return", _fmt_pct(s.get("return_pct"))),
+            ("vs Buy & Hold", _fmt_pct(data.get("baseline_return_pct"))),
+            ("Sharpe", _fmt_num(s.get("sharpe"))),
+            ("Max Drawdown", _fmt_pct(s.get("max_drawdown_pct"))),
+            ("Trades / week", _fmt_num(s.get("trades_per_week"))),
+            ("Re-tunes (switched/total)", f"{data.get('n_switched', 0)}/{data.get('n_retunes', 0)}"),
+            ("Time in Market", _fmt_pct(s.get("time_in_market_pct"))),
+            ("Net P&L", _fmt_money(s.get("net_pnl"))),
+        ]
+        for i, (label, value) in enumerate(cells):
+            col = i % 4
+            row = (i // 4) * 2
+            tk.Label(self.stats_frame, text=label, bg="white", fg="#777",
+                     font=("Arial", 9)).grid(row=row, column=col, sticky="w", padx=(0, 18))
+            tk.Label(self.stats_frame, text=value, bg="white",
+                     font=("Arial", 12, "bold")).grid(row=row + 1, column=col, sticky="w", padx=(0, 18))
+
+    def _render_params(self, plog):
+        self.tree.delete(*self.tree.get_children())
+        # Newest first, matching the JS panel.
+        for p in reversed(plog):
+            self.tree.insert("", "end", values=(
+                _iso_day(p.get("time")),
+                f"{p.get('mom_lookback')}/{p.get('mom_skip')}",
+                p.get("value_lookback"),
+                p.get("top_n"),
+                _fmt_num(p.get("objective")),
+                "✓ switched" if p.get("switched") else "held",
+            ))
+        if not plog:
+            self.tree.insert("", "end", values=("No re-tunes", "", "", "", "", ""))
+
+    # -- misc ------------------------------------------------------------------
+    @staticmethod
+    def _norm_date(raw: str) -> str:
+        """Validate a 'YYYY-MM-DD' date and return it normalized (the study uses
+        daily bars, so no intraday component). Raises ValueError if malformed."""
+        return _dt.datetime.strptime(raw.strip(), "%Y-%m-%d").strftime("%Y-%m-%d")
+
+    def _set_status(self, text, error=False):
+        self.status.config(text=text, fg="#c0392b" if error else "#555")

--- a/tools/Python/PyDemo/study/t4_fetch.py
+++ b/tools/Python/PyDemo/study/t4_fetch.py
@@ -1,0 +1,167 @@
+"""study/t4_fetch.py
+
+Source the Portfolio Study's futures bars from T4 the SAME way the Backtester
+does — via :class:`chart.history.ChartHistory`, which is binary-first with a JSON
+fallback. The study's old path (``algo-py``'s ``research.data.fetch_symbol``)
+called ``get_barchart_binary`` with no fallback, so it died on the binary
+``/chart/barchart`` 400 that ChartHistory recovers from via JSON.
+
+We fetch each futures instrument here (in PyDemo's process, where the live
+authenticated client lives), write one ``{key}.csv`` per instrument, and let the
+study run over them through its existing, reliable ``--source csv`` path. No
+token plumbing into the subprocess, no fragile binary-only fetch.
+
+Daily bars only (the rotation study is daily). BLOCKING (HTTP) — call from a
+worker thread, never the Tk/asyncio main thread.
+"""
+
+from __future__ import annotations
+
+import csv
+import os
+from typing import Callable, List, Optional, Tuple
+
+from chart.history import ChartHistory
+
+_DAILY = 86400  # seconds; ChartHistory maps this to T4 ("Day", 1)
+
+
+class FetchError(RuntimeError):
+    """Raised when a futures instrument yields no bars over the window."""
+
+
+# Futures basket, mirrored from algo-py/research/config.py (EQUITY_INDEX_FUTURES).
+# (key, contract_id, [exchange candidates tried in order]). The key names the CSV
+# file and the study's DataFrame column, so it must match the futures basket keys.
+_FUTURES: List[Tuple[str, str, List[str]]] = [
+    ("es", "ES", ["CME_Eq", "CME_E", "CME"]),
+    ("nq", "NQ", ["CME_Eq", "CME_E", "CME"]),
+    # YM (E-mini Dow) is a CBOT product; some T4 feeds group it under CME_Eq, so
+    # try that too. On feeds that carry none of these it's dropped (see below).
+    ("ym", "YM", ["CBOT", "CME_CBOT", "CME_Eq", "CME"]),
+    ("rty", "RTY", ["CME_Eq", "CME_E", "CME"]),
+]
+
+# The rotation study needs a basket; run on whatever's available down to this many.
+_MIN_SYMBOLS = 2
+
+_CSV_HEADER = ("date", "open", "high", "low", "close", "volume")
+
+
+def _tz_offset_hours(client) -> float:
+    try:
+        cfg = (getattr(client, "config", None) or {}).get("chart", {}) or {}
+        return float(cfg.get("tz_offset_hours", 0.0) or 0.0)
+    except Exception:  # noqa: BLE001 - best-effort
+        return 0.0
+
+
+def _live_price_for(client, contract_id: str) -> Optional[float]:
+    """The charted last price, but only when it's the SAME contract we're fetching
+    (so JSON price-scaling calibrates against the right instrument)."""
+    if (getattr(client, "md_contract_id", None) or "").upper() != contract_id.upper():
+        return None
+    cw = getattr(client, "chart_window", None)
+    return getattr(cw, "_last_price", None) if cw else None
+
+
+def fetch_futures_csvs(
+    client,
+    start: str,
+    end: str,
+    out_dir: str,
+    on_line: Optional[Callable[[str], None]] = None,
+) -> List[Tuple[str, int]]:
+    """Fetch daily bars for the ES/NQ/YM/RTY futures over [start, end] and write one
+    ``{key}.csv`` per instrument that returns data into ``out_dir``.
+
+    Instruments that return no bars (e.g. YM on a feed that doesn't carry the Dow)
+    are SKIPPED with a warning rather than failing the run — the study then trades
+    the available subset. Returns [(key, n_bars), ...] for the symbols written.
+
+    Raises:
+        FetchError: no token, or fewer than _MIN_SYMBOLS instruments return data.
+    """
+    token = getattr(client, "jw_token", None)
+    if not token:
+        raise FetchError("Connect/login to T4 first — the study needs a live token.")
+    api = getattr(client, "apiUrl", None)
+    base_url = (api.rstrip("/") + "/chart") if api else None
+    tz = _tz_offset_hours(client)
+
+    def emit(msg: str) -> None:
+        if on_line is not None:
+            try:
+                on_line(msg)
+            except Exception:  # noqa: BLE001 - progress is best-effort
+                pass
+
+    results: List[Tuple[str, int]] = []
+    dropped: List[str] = []
+    for key, contract_id, candidates in _FUTURES:
+        live_price = _live_price_for(client, contract_id)
+        bars: list = []
+        source = "none"
+        used_exchange = None
+        hist = ChartHistory(token, base_url=base_url, tz_offset_hours=tz)
+        try:
+            for exch in candidates:
+                # Prefer a roll-stitched continuous series for the multi-month
+                # window; if that yields nothing, retry the same exchange without
+                # continuation (some sim feeds don't serve it).
+                for cont in ("Volume", None):
+                    got, src = hist.fetch(
+                        exchange_id=exch,
+                        contract_id=contract_id,
+                        market_id=None,
+                        interval_seconds=_DAILY,
+                        trade_date_start=start,
+                        trade_date_end=end,
+                        live_price=live_price,
+                        continuation_type=cont,
+                    )
+                    if got:
+                        bars, source, used_exchange = got, src, exch
+                        break
+                if bars:
+                    break
+        finally:
+            hist.close()
+
+        if not bars:
+            dropped.append(key)
+            emit(f"[fetch] {key}: no bars (tried {', '.join(candidates)}) — skipping")
+            continue
+
+        path = os.path.join(out_dir, f"{key}.csv")
+        _write_csv(path, bars)
+        results.append((key, len(bars)))
+        emit(f"[fetch] {key}: {len(bars)} daily bars via {source} ({used_exchange})")
+
+    if len(results) < _MIN_SYMBOLS:
+        have = ", ".join(k for k, _ in results) or "none"
+        raise FetchError(
+            f"Only {len(results)} instrument(s) returned data ({have}); the rotation "
+            f"study needs at least {_MIN_SYMBOLS}. Widen the From/To window or check "
+            "T4 market-data entitlements."
+        )
+    if dropped:
+        emit(f"[fetch] running on {', '.join(k for k, _ in results)} "
+             f"(unavailable on this feed: {', '.join(dropped)})")
+    return results
+
+
+def _write_csv(path: str, bars: list) -> None:
+    """Write ChartHistory bars ({time: datetime, open, high, low, close, volume})
+    to a daily OHLCV CSV that research.data.load_csv_symbol can read."""
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        w = csv.writer(f)
+        w.writerow(_CSV_HEADER)
+        for b in bars:
+            t = b.get("time")
+            day = t.strftime("%Y-%m-%d") if hasattr(t, "strftime") else str(t)
+            w.writerow([
+                day,
+                b.get("open"), b.get("high"), b.get("low"), b.get("close"),
+                int(b.get("volume", 0) or 0),
+            ])

--- a/tools/Python/PyDemo/t4_gui.py
+++ b/tools/Python/PyDemo/t4_gui.py
@@ -8,9 +8,12 @@ from expiry_picker_dialog import Expiry_Picker_Dialog
 from contract_picker import Contract_Picker
 class T4_GUI(tk.Tk):
 
-    def __init__(self, root, client):
+    def __init__(self, root, client, loop=None):
         self.root = root
         self.client = client
+        # The asyncio loop, used by open_chart() to schedule the chart window's
+        # async run(). Falls back to asyncio.get_event_loop() if not supplied.
+        self.loop = loop
         self.root.title("T4 API Demo")
         self.root.geometry("1750x1380")
 
@@ -59,44 +62,58 @@ class T4_GUI(tk.Tk):
         self.disconnect_button = tk.Button(self.connect_frame, text="Disconnect", bg="#3b82f6", fg="white", command=self.end_connection)
         self.disconnect_button.grid(row=3, column=3, padx=5)
 
+        #portfolio study (walk-forward rotation backtest viewer). A global tool,
+        #not market-specific (CSV mode needs no market/login), so it lives on the
+        #top connection bar rather than crowding the Market Data box.
+        self.portfolio_study_button = tk.Button(self.connect_frame, text="Portfolio Study", bg="#6b7280", fg="white", command=self.open_portfolio_study)
+        self.portfolio_study_button.grid(row=3, column=4, padx=(20, 5))
+
+        #single-instrument backtester (JSDemo-parity strategies on T4 bars).
+        #Same global tool / guarded-lazy-import pattern as Portfolio Study.
+        self.backtester_button = tk.Button(self.connect_frame, text="Backtester", bg="#6b7280", fg="white", command=self.open_backtester)
+        self.backtester_button.grid(row=3, column=5, padx=5)
+
+        #companion chart window (lightweight-charts). Opens on demand rather than
+        #at startup — same global tool / guarded-lazy-import pattern as the others.
+        self.chart_button = tk.Button(self.connect_frame, text="Chart", bg="#6b7280", fg="white", command=self.open_chart)
+        self.chart_button.grid(row=3, column=6, padx=5)
+
 
         #market frame
         self.market_frame = tk.Frame(self.root, bg="white", bd=1, relief="groove")
         self.market_frame.place(relx=0.05, rely=0.25, relwidth=0.44, relheight=0.3)
 
-        #allows for resizing
+        #allows for resizing — let the container fill the whole frame, and let the
+        #quotes row (market_inner) absorb the vertical slack.
         self.market_frame.columnconfigure(0, weight=1)
-        self.market_frame.rowconfigure(2, weight=1)
+        self.market_frame.rowconfigure(0, weight=1)
 
         #container for data. ensures things are touching the borders (padx and pady)
         market_container = tk.Frame(self.market_frame, bg="white", padx=20, pady=20)
         market_container.grid(row=0, column=0, sticky="nsew")
+        market_container.columnconfigure(0, weight=1)
+        market_container.rowconfigure(2, weight=1)
 
         market_title = tk.Label(market_container, text="Market Data", font=("Arial", 16, "bold"), bg="white")
         market_title.grid(row=0, column=0, sticky="w", pady=(0, 10))
         
-        tk.Button(
-            self.market_frame,
-            text="Pick a Contract",
-            command=self.open_contract_picker
-        ).grid(row=5, column=0, pady=10)
-
-        #expiry button
-        tk.Button(
-            self.market_frame,
-            text="Expiry",
-            command = self.open_expiry_picker
-        ).grid(row = 6, column = 0, pady= 5)
-        # market header 
+        # market header
         self.market_header_label = tk.Label(market_container, text="...", font=("Arial", 14), bg="white", fg="#3b82f6")
         self.market_header_label.grid(row=0, column=1, sticky="e", padx=(10, 0), pady=(0, 10))
 
         separator = tk.Frame(market_container, height=2, bg="#3b82f6", bd=0)
-        separator.grid(row=1, column=0, sticky="ew", pady=(0, 10))
+        separator.grid(row=1, column=0, columnspan=2, sticky="ew", pady=(0, 10))
 
         #we will put the dynamic changing ui within this frame. (the same pattern for the following three big frames)
         self.market_inner = tk.Frame(market_container, bg="#f9f9f9")
-        self.market_inner.grid(row=2, column=0, sticky="nsew")
+        self.market_inner.grid(row=2, column=0, columnspan=2, sticky="nsew")
+
+        #button bar beneath the quotes: contract + expiry side by side, so they no
+        #longer crowd the quote area or sit on stray market_frame rows.
+        button_bar = tk.Frame(market_container, bg="white")
+        button_bar.grid(row=3, column=0, columnspan=2, sticky="w", pady=(10, 0))
+        tk.Button(button_bar, text="Pick a Contract", command=self.open_contract_picker).grid(row=0, column=0, padx=(0, 8))
+        tk.Button(button_bar, text="Expiry", command=self.open_expiry_picker).grid(row=0, column=1)
 
 
         #Submit frame
@@ -377,22 +394,26 @@ class T4_GUI(tk.Tk):
 
         # Container for alignment
         box_container = tk.Frame(self.market_inner, bg="white")
-        box_container.pack(expand=True, fill="x", pady=10)
+        box_container.pack(expand=True, fill="both", pady=6)
 
-        # Set up a 3-column grid layout
+        # Set up a 3-column grid layout (equal widths so the boxes share the frame
+        # evenly and never overflow it).
         box_container.columnconfigure(0, weight=1)
         box_container.columnconfigure(1, weight=1)
         box_container.columnconfigure(2, weight=1)
+        box_container.rowconfigure(0, weight=1)
 
         def create_box(parent, col, title, qty, price, color):
-            box = tk.Frame(parent, bg="white", bd=1, relief="solid", padx=20, pady=15)
-            box.grid(row=0, column=col, padx=20, sticky="nsew")
+            # Tight padding + a smaller price font keep three boxes readable inside
+            # the narrow Market Data frame (it can't grow — Submit sits beside it).
+            box = tk.Frame(parent, bg="white", bd=1, relief="solid", padx=8, pady=8)
+            box.grid(row=0, column=col, padx=6, sticky="nsew")
 
-            tk.Label(box, text=title, font=("Arial", 12, "bold"), bg="white").pack()
+            tk.Label(box, text=title, font=("Arial", 11, "bold"), bg="white").pack()
             tk.Label(
                 box,
                 text=f"{qty}@{price}",
-                font=("Arial", 18, "bold"),
+                font=("Arial", 14, "bold"),
                 fg=color,
                 bg="white"
             ).pack()
@@ -444,6 +465,96 @@ class T4_GUI(tk.Tk):
     #opens the expirty dialog
     def open_expiry_picker(self):
         Expiry_Picker_Dialog(master=self.root, client=self.client)
+
+    #opens the walk-forward portfolio study results viewer. Imported lazily and
+    #guarded so a missing matplotlib (or the sibling algo-py package) disables the
+    #feature gracefully instead of breaking the whole GUI — same pattern as
+    #main.py::_start_chart.
+    def open_portfolio_study(self):
+        try:
+            from study.study_window import PortfolioStudyWindow
+        except Exception as exc:  # noqa: BLE001
+            from tkinter import messagebox
+            messagebox.showerror(
+                "Portfolio Study unavailable",
+                f"Could not open the study viewer: {exc}\n\n"
+                "It needs matplotlib installed (pip install matplotlib) and the "
+                "algo-py research package alongside PyDemo.",
+            )
+            return
+        PortfolioStudyWindow(self.root, self.client)
+
+    #opens the single-instrument backtester. Same guarded lazy import as the
+    #portfolio study so a missing matplotlib / algo-py package degrades to a
+    #dialog instead of breaking the GUI.
+    def open_backtester(self):
+        try:
+            from backtest.backtest_window import BacktestWindow
+        except Exception as exc:  # noqa: BLE001
+            from tkinter import messagebox
+            messagebox.showerror(
+                "Backtester unavailable",
+                f"Could not open the backtester: {exc}\n\n"
+                "It needs matplotlib installed (pip install matplotlib).",
+            )
+            return
+        BacktestWindow(self.root, self.client)
+
+    #opens the companion chart window (lightweight-charts) on demand. Previously
+    #launched at startup by main.py::_start_chart; now button-triggered. Builds the
+    #ChartWindow, chains its market/account callbacks onto the GUI's own handlers so
+    #the quote boxes and tables keep updating, exposes it as client.chart_window for
+    #the Backtester/Study, and schedules its async run(). Guarded lazy import like
+    #the other tool buttons; a re-open guard avoids spawning a second window.
+    def open_chart(self):
+        existing = getattr(self.client, "chart_window", None)
+        if existing is not None and existing._chart_live():
+            return  # a chart window is already open
+
+        try:
+            from chart.chart_window import ChartWindow
+        except Exception as exc:  # noqa: BLE001
+            from tkinter import messagebox
+            messagebox.showerror(
+                "Chart unavailable",
+                f"Could not open the chart: {exc}\n\n"
+                "It needs lightweight-charts installed (pip install lightweight-charts).",
+            )
+            return
+
+        config = getattr(self.client, "config", {}) or {}
+        chart_cfg = config.get("chart", {}) if isinstance(config, dict) else {}
+
+        loop = self.loop or asyncio.get_event_loop()
+        cw = ChartWindow(
+            self.client, loop,
+            default_interval_seconds=chart_cfg.get("interval_seconds", 60),
+            initial_load_days=chart_cfg.get("initial_load_days", 2),
+            tz_offset_hours=chart_cfg.get("tz_offset_hours", 0.0),
+            target_bars=chart_cfg.get("target_bars", 500),
+            max_load_days=chart_cfg.get("max_load_days", 120),
+            chunk_days=chart_cfg.get("chunk_days", 1),
+            scroll_buffer_days=chart_cfg.get("scroll_buffer_days", 1.0),
+            history_floor=chart_cfg.get("history_floor", "2000-01-01"),
+        )
+
+        # Chain onto the GUI's OWN handlers (not the current client callbacks) so
+        # re-opening after a close never stacks wrappers — each open rebuilds the
+        # chain from a single, known base.
+        def _mkt(data, _gui=self.update_market_ui, _cw=cw):
+            _gui(data)
+            _cw.on_market_update(data)
+
+        def _acct(data, _gui=self.handle_account_update, _cw=cw):
+            _gui(data)
+            _cw.on_account_update(data)
+
+        self.client.on_market_update = _mkt
+        self.client.on_account_update = _acct
+        # Expose the chart window so other tools (Backtester / Study) can read its
+        # already-loaded bars without refetching.
+        self.client.chart_window = cw
+        asyncio.ensure_future(cw.run(), loop=loop)
 
     async def on_submit_order(self):
         print("Market ID:", self.client.current_market_id)

--- a/tools/Python/PyDemo/tests/test_aggregator.py
+++ b/tools/Python/PyDemo/tests/test_aggregator.py
@@ -1,0 +1,91 @@
+"""Unit tests for chart.aggregator (TickStore + CandleAggregator)."""
+
+import os
+import sys
+from datetime import datetime, timezone
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from chart.aggregator import CandleAggregator, TickStore  # noqa: E402
+
+
+def _epoch(y, mo, d, h, mi, s):
+    return datetime(y, mo, d, h, mi, s, tzinfo=timezone.utc).timestamp()
+
+
+def test_tickstore_ring_buffer_bounded():
+    store = TickStore(capacity=3)
+    for i in range(5):
+        store.push("ES", {"price": i})
+    ticks = store.get("ES")
+    assert len(ticks) == 3
+    assert [t["price"] for t in ticks] == [2, 3, 4]
+
+
+def test_tickstore_clear():
+    store = TickStore()
+    store.push("ES", {"price": 1})
+    store.push("CL", {"price": 2})
+    store.clear("ES")
+    assert store.get("ES") == []
+    assert len(store.get("CL")) == 1
+    store.clear()
+    assert store.get("CL") == []
+
+
+def test_single_bucket_ohlc():
+    agg = CandleAggregator(interval_seconds=60)
+    t0 = _epoch(2024, 1, 15, 9, 30, 0)
+    agg.add_tick(100.0, 1, t0 + 1)
+    agg.add_tick(105.0, 2, t0 + 10)
+    agg.add_tick(95.0, 1, t0 + 20)
+    bar = agg.add_tick(102.0, 3, t0 + 59)
+    assert bar["open"] == 100.0
+    assert bar["high"] == 105.0
+    assert bar["low"] == 95.0
+    assert bar["close"] == 102.0
+    assert bar["volume"] == 7
+    # Bar time is bucket start.
+    assert bar["time"] == datetime(2024, 1, 15, 9, 30, 0, tzinfo=timezone.utc)
+
+
+def test_bucket_rollover_starts_new_bar():
+    agg = CandleAggregator(interval_seconds=60)
+    t0 = _epoch(2024, 1, 15, 9, 30, 0)
+    agg.add_tick(100.0, 1, t0 + 5)
+    bar2 = agg.add_tick(110.0, 2, t0 + 65)  # next minute
+    assert bar2["open"] == 110.0
+    assert bar2["volume"] == 2
+    assert bar2["time"] == datetime(2024, 1, 15, 9, 31, 0, tzinfo=timezone.utc)
+
+
+def test_out_of_order_tick_ignored():
+    agg = CandleAggregator(interval_seconds=60)
+    t0 = _epoch(2024, 1, 15, 9, 30, 0)
+    agg.add_tick(100.0, 1, t0 + 65)  # establishes bucket 9:31
+    late = agg.add_tick(99.0, 1, t0 + 5)  # belongs to 9:30 - too late
+    assert late is None
+
+
+def test_seed_last_bar_continues_same_bucket():
+    agg = CandleAggregator(interval_seconds=60)
+    t0 = datetime(2024, 1, 15, 9, 30, 0, tzinfo=timezone.utc)
+    agg.seed_last_bar({"time": t0, "open": 50.0, "high": 55.0, "low": 48.0,
+                       "close": 52.0, "volume": 100})
+    # A tick in the same minute should fold into the seeded bar (open preserved).
+    bar = agg.add_tick(60.0, 5, t0.timestamp() + 30)
+    assert bar["open"] == 50.0
+    assert bar["high"] == 60.0
+    assert bar["low"] == 48.0
+    assert bar["close"] == 60.0
+    assert bar["volume"] == 105
+
+
+def test_reset_switches_interval():
+    agg = CandleAggregator(interval_seconds=60)
+    agg.reset(interval_seconds=15)
+    assert agg.interval_seconds == 15
+    t0 = _epoch(2024, 1, 15, 9, 30, 0)
+    b1 = agg.add_tick(100.0, 1, t0 + 1)
+    b2 = agg.add_tick(101.0, 1, t0 + 20)  # 20s later -> new 15s bucket
+    assert b1["time"] != b2["time"]

--- a/tools/Python/PyDemo/tests/test_bars_df.py
+++ b/tools/Python/PyDemo/tests/test_bars_df.py
@@ -1,0 +1,87 @@
+"""Tests for ChartWindow._bars_df: sort + second-unique de-duplication.
+
+lightweight-charts truncates bar time to whole seconds and rejects a setData
+array that is not strictly ascending / unique, so _bars_df must guarantee that.
+"""
+
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from chart.chart_window import ChartWindow  # noqa: E402
+
+
+def _dt(s):
+    return datetime(2024, 1, 15, 9, 30, s, tzinfo=timezone.utc)
+
+
+def _series(n):
+    """n bars at distinct, ascending 15s timestamps; close == index (0..n-1)."""
+    base = datetime(2024, 1, 15, 0, 0, 0, tzinfo=timezone.utc)
+    return [
+        {"time": base + timedelta(seconds=15 * i),
+         "open": i, "high": i, "low": i, "close": i, "volume": 1}
+        for i in range(n)
+    ]
+
+
+def test_empty_returns_empty_with_columns():
+    df = ChartWindow._bars_df([])
+    assert list(df.columns) == ["time", "open", "high", "low", "close", "volume"]
+    assert df.empty
+
+
+def test_sorts_by_time():
+    bars = [
+        {"time": _dt(30), "open": 3, "high": 3, "low": 3, "close": 3, "volume": 1},
+        {"time": _dt(10), "open": 1, "high": 1, "low": 1, "close": 1, "volume": 1},
+        {"time": _dt(20), "open": 2, "high": 2, "low": 2, "close": 2, "volume": 1},
+    ]
+    df = ChartWindow._bars_df(bars)
+    assert [t.second for t in df["time"]] == [10, 20, 30]
+
+
+def test_drops_second_duplicates_keeping_last():
+    bars = [
+        {"time": _dt(10), "open": 1, "high": 1, "low": 1, "close": 1, "volume": 1},
+        {"time": _dt(10), "open": 9, "high": 9, "low": 9, "close": 9, "volume": 5},  # dup second
+        {"time": _dt(20), "open": 2, "high": 2, "low": 2, "close": 2, "volume": 1},
+    ]
+    df = ChartWindow._bars_df(bars)
+    assert len(df) == 2
+    # The kept row at second 10 is the last one (close 9, volume 5).
+    row = df[df["time"].apply(lambda t: t.second) == 10].iloc[0]
+    assert row["close"] == 9
+    assert row["volume"] == 5
+
+
+def test_max_bars_caps_to_most_recent():
+    # 5000 bars capped to 2000 -> keep the newest 2000 (close 3000..4999).
+    df = ChartWindow._bars_df(_series(5000), max_bars=2000)
+    assert len(df) == 2000
+    assert df["close"].iloc[0] == 3000     # earliest kept bar
+    assert df["close"].iloc[-1] == 4999    # most-recent bar preserved
+
+
+def test_max_bars_none_keeps_all():
+    df = ChartWindow._bars_df(_series(500), max_bars=None)
+    assert len(df) == 500
+
+
+def test_max_bars_no_effect_when_under_cap():
+    df = ChartWindow._bars_df(_series(100), max_bars=3000)
+    assert len(df) == 100
+
+
+def test_timestamps_strictly_ascending_at_second_resolution():
+    bars = [
+        {"time": _dt(s % 60), "open": 1, "high": 1, "low": 1, "close": 1, "volume": 1}
+        for s in (10, 10, 20, 20, 30)
+    ]
+    df = ChartWindow._bars_df(bars)
+    import pandas as pd
+    secs = (pd.to_datetime(df["time"]).astype("int64") // 10 ** 9).tolist()
+    assert secs == sorted(secs)
+    assert len(secs) == len(set(secs))

--- a/tools/Python/PyDemo/tests/test_bt_engine.py
+++ b/tools/Python/PyDemo/tests/test_bt_engine.py
@@ -1,0 +1,110 @@
+"""Unit tests for the ported backtest engine (SimBroker / Portfolio / Backtester).
+
+These pin the invariants that must match JSDemo: one-bar lag on market fills,
+OCO stop-first resolution, weighted-avg PnL accounting, and the stats math.
+"""
+
+import math
+
+from backtest.backtester import Backtester
+from backtest.strategies.base import Strategy
+
+
+def _bar(t, o, h, l, c, v=0):
+    return {"time": t, "open": o, "high": h, "low": l, "close": c, "volume": v}
+
+
+class BuyOnceMarket(Strategy):
+    """Buys 1 (plain market) on the first bar it sees, then never again."""
+    def __init__(self, params=None):
+        super().__init__(params)
+        self._done = False
+
+    def on_bar(self, bar):
+        if not self._done:
+            self._done = True
+            self.buy(1, {"type": "market"})
+
+
+class BuyBracketOnce(Strategy):
+    """Buys 1 with a TP/SL bracket on the first bar, then never again."""
+    def __init__(self, params=None):
+        super().__init__(params)
+        self._done = False
+
+    def on_bar(self, bar):
+        if not self._done:
+            self._done = True
+            self.buy(1, {"type": "market", "tp": 110, "sl": 90})
+
+
+def test_one_bar_lag_market_fills_next_open():
+    bars = [
+        _bar(1, 100, 100, 100, 100),   # strategy buys on this close
+        _bar(2, 105, 106, 104, 105),   # market should fill at THIS open (105)
+        _bar(3, 105, 105, 105, 105),
+    ]
+    res = Backtester().run(bars, BuyOnceMarket(), {"starting_cash": 100000})
+    fills = res["trades"]
+    # First fill is the entry at bar2 open.
+    assert fills[0]["time"] == 2
+    assert fills[0]["price"] == 105
+    assert fills[0]["side"] == 1
+
+
+def test_oco_stop_resolves_first():
+    # Entry fills at bar2 open (100); bar3 spans BOTH tp(110) and sl(90) → the
+    # stop must win (pessimistic), closing the long at 90 for a -10 loss.
+    bars = [
+        _bar(1, 100, 100, 100, 100),
+        _bar(2, 100, 100, 100, 100),   # entry fills here @ 100, bracket installed
+        _bar(3, 100, 115, 85, 100),    # both TP and SL in range
+        _bar(4, 100, 100, 100, 100),
+    ]
+    res = Backtester().run(bars, BuyBracketOnce(), {"starting_cash": 100000})
+    closing = [t for t in res["trades"] if t["closing"]]
+    assert len(closing) == 1
+    assert closing[0]["price"] == 90
+    assert math.isclose(closing[0]["pnl"], -10.0, rel_tol=1e-12)
+    # No open position left, so the run's net profit equals that loss.
+    assert math.isclose(res["stats"]["netProfit"], -10.0, rel_tol=1e-12)
+
+
+def test_pnl_point_value_and_commission():
+    # Long 1 @100 (bar2 open), force-closed at last close (120) → +20 points.
+    bars = [
+        _bar(1, 100, 100, 100, 100),
+        _bar(2, 100, 100, 100, 100),
+        _bar(3, 120, 120, 120, 120),
+    ]
+    res = Backtester().run(bars, BuyOnceMarket(),
+                           {"starting_cash": 100000, "point_value": 2, "commission": 1})
+    # gross = (120-100)*1*2 = 40 ; commissions = 1 entry + 1 exit = 2 → net 38.
+    assert math.isclose(res["stats"]["netProfit"], 38.0, rel_tol=1e-12)
+    assert res["stats"]["numTrades"] == 1
+    # finalEquity is the LAST per-bar equity mark (bar3 close: +40 unrealized,
+    # only the entry commission deducted = 100039). force_close realizes the
+    # exit (and its commission) afterwards WITHOUT re-marking the curve — a
+    # faithful JSDemo quirk: finalEquity (100039) != startingCash+netProfit (100038).
+    assert res["stats"]["finalEquity"] == 100039.0
+
+
+def test_equity_curve_marks_unrealized():
+    bars = [
+        _bar(1, 100, 100, 100, 100),
+        _bar(2, 100, 100, 100, 100),   # entry @100
+        _bar(3, 110, 110, 110, 110),   # unrealized +10 marked at close
+    ]
+    res = Backtester().run(bars, BuyOnceMarket(), {"starting_cash": 100000})
+    eq = res["equity_curve"]
+    assert len(eq) == 3
+    # At bar3 close the open long is +10 over cash.
+    assert math.isclose(eq[2]["value"], 100010.0, rel_tol=1e-12)
+
+
+def test_too_few_bars_raises():
+    try:
+        Backtester().run([_bar(1, 1, 1, 1, 1)], BuyOnceMarket())
+    except ValueError:
+        return
+    assert False, "expected ValueError for < 2 bars"

--- a/tools/Python/PyDemo/tests/test_bt_indicators.py
+++ b/tools/Python/PyDemo/tests/test_bt_indicators.py
@@ -1,0 +1,69 @@
+"""Unit tests for the ported backtest indicators (parity with JSDemo)."""
+
+import math
+
+from backtest import indicators as I
+
+
+def test_sma_basic():
+    assert I.sma([1, 2, 3, 4, 5], 3) == 4.0          # (3+4+5)/3
+    assert I.sma([1, 2], 3) is None                   # too short
+
+
+def test_ema_constant_series_is_constant():
+    # SMA-seeded EMA of a flat series equals that value.
+    assert I.ema([5, 5, 5, 5, 5], 2) == 5.0
+    assert I.ema([5], 2) is None
+
+
+def test_ema_known_value():
+    # period=2, k=2/3. seed = SMA(first 2)= (1+2)/2 = 1.5.
+    # i=2: 3*2/3 + 1.5*1/3 = 2 + 0.5 = 2.5
+    # i=3: 4*2/3 + 2.5*1/3 = 2.6667 + 0.8333 = 3.5
+    assert math.isclose(I.ema([1, 2, 3, 4], 2), 3.5, rel_tol=1e-9)
+
+
+def test_rsi_all_gains_is_100():
+    assert I.rsi([1, 2, 3, 4, 5, 6], 5) == 100.0
+    assert I.rsi([1, 2], 5) is None                   # needs period+1
+
+
+def test_rsi_known_value():
+    # alternating +2/-1 deltas over 4 → avgGain=2*... compute directly.
+    vals = [10, 12, 11, 13, 12]   # deltas: +2,-1,+2,-1 over period=4
+    # gains=4, losses=2 → avgGain=1, avgLoss=0.5 → rs=2 → 100-100/3 = 66.667
+    assert math.isclose(I.rsi(vals, 4), 100 - 100 / 3, rel_tol=1e-9)
+
+
+def test_stdev_population():
+    # Classic example: population stdev of this set is exactly 2.0.
+    assert math.isclose(I.stdev([2, 4, 4, 4, 5, 5, 7, 9], 8), 2.0, rel_tol=1e-12)
+
+
+def test_highest_lowest():
+    assert I.highest([3, 1, 4, 1, 5, 9, 2], 3) == 9
+    assert I.lowest([3, 1, 4, 1, 5, 9, 2], 3) == 2
+
+
+def test_macd_constant_series_is_zero():
+    m = I.macd([5] * 40, 12, 26, 9)
+    assert m is not None
+    assert math.isclose(m["macd"], 0.0, abs_tol=1e-12)
+    assert math.isclose(m["signal"], 0.0, abs_tol=1e-12)
+    assert math.isclose(m["hist"], 0.0, abs_tol=1e-12)
+
+
+def test_macd_rising_series_positive():
+    # A steadily rising series → fast EMA above slow EMA → macd > 0.
+    m = I.macd(list(range(1, 60)), 12, 26, 9)
+    assert m is not None and m["macd"] > 0
+    assert I.macd([1], 12, 26, 9) is None             # < 2 values
+
+
+def test_atr_known_value():
+    highs = [10, 11, 12]
+    lows = [9, 10, 11]
+    closes = [9.5, 10.5, 11.5]
+    # TR(1)=max(1,|11-9.5|,|10-9.5|)=1.5 ; TR(2)=max(1,|12-10.5|,|11-10.5|)=1.5
+    assert math.isclose(I.atr(highs, lows, closes, 2), 1.5, rel_tol=1e-12)
+    assert I.atr(highs, lows, closes, 5) is None       # too short

--- a/tools/Python/PyDemo/tests/test_bt_strategies.py
+++ b/tools/Python/PyDemo/tests/test_bt_strategies.py
@@ -1,0 +1,52 @@
+"""Integration tests: each core strategy runs end-to-end through the engine on a
+synthetic oscillating series, trades, and emits its declared plot keys."""
+
+import math
+
+from backtest.backtester import Backtester
+from backtest.strategies import REGISTRY
+
+
+def _synthetic_bars(n=400):
+    """A sine wave around 100 (amp 8) with a slow uptrend — enough swings that
+    every long/flat strategy enters and exits at least once."""
+    bars = []
+    for i in range(n):
+        mid = 100 + 0.02 * i + 8 * math.sin(i / 9.0)
+        o = mid + 0.5 * math.sin(i / 3.0)
+        c = mid
+        h = max(o, c) + 1.0
+        l = min(o, c) - 1.0
+        bars.append({"time": 1_600_000_000 + i * 60, "open": o, "high": h,
+                     "low": l, "close": c, "volume": 100})
+    return bars
+
+
+def test_all_strategies_run_and_emit_plots():
+    bars = _synthetic_bars()
+    for key, cls in REGISTRY.items():
+        strat = cls()  # defaults
+        res = Backtester().run(bars, strat, {"starting_cash": 100000, "point_value": 1},
+                               interval_ms=60_000)
+        # Result shape.
+        assert set(res) >= {"equity_curve", "trades", "stats", "plots", "config"}
+        assert len(res["equity_curve"]) == len(bars)
+        # Stats keys present.
+        for k in ("netProfit", "totalReturnPct", "maxDrawdown", "numTrades",
+                  "winRatePct", "profitFactor", "sharpe", "finalEquity"):
+            assert k in res["stats"], f"{key} missing stat {k}"
+        # Every declared plot key shows up in at least one bar's values.
+        declared = {p["key"] for p in cls.PLOTS}
+        seen = set()
+        for p in res["plots"]:
+            seen |= set(p["values"].keys())
+        missing = declared - seen
+        assert not missing, f"{key} never emitted plots {missing}"
+
+
+def test_long_flat_strategies_never_go_short():
+    """The core 4 are long/flat — net position must never be negative."""
+    bars = _synthetic_bars()
+    for key, cls in REGISTRY.items():
+        res = Backtester().run(bars, cls(), {"starting_cash": 100000})
+        assert all(p["net"] >= 0 for p in res["plots"]), f"{key} went short"

--- a/tools/Python/PyDemo/tests/test_chart_load_supersede.py
+++ b/tools/Python/PyDemo/tests/test_chart_load_supersede.py
@@ -1,0 +1,103 @@
+"""Chart overlap fix: concurrent _load_history calls are serialized by a
+generation token so only the newest load mutates the chart (set/recompute).
+
+This guards against duplicate indicator line series: an interval switch + market
+update interleaving (or rapid switches) used to run two _load_history passes,
+each calling chart.set() + indicators.recompute(), stacking lines on top of each
+other (chart.set() does NOT wipe create_line series).
+"""
+
+import asyncio
+
+import chart.chart_window as cw_mod
+from chart.chart_window import ChartWindow
+
+
+class FakeChart:
+    def __init__(self):
+        self.is_alive = True
+        self.set_calls = 0
+        self.precision_calls = 0
+
+    def precision(self, _d):
+        self.precision_calls += 1
+
+    def set(self, _df):
+        self.set_calls += 1
+
+    def fit(self):
+        pass
+
+    def watermark(self, _s):
+        pass
+
+
+class FakeIndicators:
+    def __init__(self):
+        self.recompute_calls = 0
+
+    def recompute(self, _df):
+        self.recompute_calls += 1
+
+
+class FakeClient:
+    market_details = {}          # .get(market_id) -> None (decimals default 2)
+    jw_token = "tok"
+    md_exchange_id = "EX"
+    md_contract_id = "C"
+    apiUrl = None
+    priceFormat = 0
+
+
+class FakeHistory:
+    """Stands in for chart.history.ChartHistory; returns an empty bar set fast."""
+
+    def __init__(self, *_a, **_k):
+        pass
+
+    def fetch(self, **_k):
+        return [], "test"
+
+    def close(self):
+        pass
+
+
+def _make_cw(loop, monkeypatch):
+    monkeypatch.setattr(cw_mod, "ChartHistory", FakeHistory)
+    cw = ChartWindow(FakeClient(), loop)
+    cw._chart = FakeChart()
+    cw._indicators = FakeIndicators()
+    cw._loaded_market_id = "M"
+    return cw
+
+
+def test_stale_load_aborts_before_mutation(monkeypatch):
+    async def run():
+        cw = _make_cw(asyncio.get_running_loop(), monkeypatch)
+        cw._load_gen = 5            # a newer load request has bumped the token
+        await cw._load_history("M", gen=3)   # stale -> must abort
+        assert cw._chart.set_calls == 0
+        assert cw._indicators.recompute_calls == 0
+
+    asyncio.run(run())
+
+
+def test_current_load_mutates_once(monkeypatch):
+    async def run():
+        cw = _make_cw(asyncio.get_running_loop(), monkeypatch)
+        cw._load_gen = 5
+        await cw._load_history("M", gen=5)   # current -> proceeds
+        assert cw._chart.set_calls == 1
+        assert cw._indicators.recompute_calls == 1
+
+    asyncio.run(run())
+
+
+def test_dead_chart_aborts(monkeypatch):
+    async def run():
+        cw = _make_cw(asyncio.get_running_loop(), monkeypatch)
+        cw._chart.is_alive = False           # window closed mid-load
+        await cw._load_history("M", gen=cw._load_gen)
+        assert cw._chart.set_calls == 0
+
+    asyncio.run(run())

--- a/tools/Python/PyDemo/tests/test_chart_lookback.py
+++ b/tools/Python/PyDemo/tests/test_chart_lookback.py
@@ -1,0 +1,40 @@
+"""Chart Bug 1: the interval-scaled history window sizing (pure function)."""
+
+from chart.chart_window import lookback_days
+
+TARGET = 500
+FLOOR = 2
+CEIL = 120
+
+
+def _bars(interval_sec, days):
+    """Approx bars over `days` at `interval_sec`, assuming ~23h trading/day."""
+    if interval_sec >= 86400:
+        return days
+    return days * (23 * 3600) // interval_sec
+
+
+def test_low_intervals_sit_at_floor():
+    # 15s and 1m hit ~500 bars well within the 2-day floor, so they stay at it.
+    assert lookback_days(15, TARGET, FLOOR, CEIL) == FLOOR
+    assert lookback_days(60, TARGET, FLOOR, CEIL) == FLOOR
+
+
+def test_higher_intervals_scale_up():
+    # 15m must load many more days than the old fixed 2 — enough for ~500 bars.
+    d15m = lookback_days(900, TARGET, FLOOR, CEIL)
+    assert d15m > FLOOR
+    assert _bars(900, d15m) >= TARGET * 0.9     # well above the old ~184 bars
+    # 1h scales further still.
+    d1h = lookback_days(3600, TARGET, FLOOR, CEIL)
+    assert d1h > d15m
+    assert _bars(3600, d1h) >= TARGET * 0.9
+
+
+def test_clamped_to_ceiling():
+    # A coarse interval × big target must never exceed the ceiling.
+    assert lookback_days(3600, 100000, FLOOR, CEIL) == CEIL
+
+
+def test_daily_uses_calendar_days():
+    assert lookback_days(86400, 300, FLOOR, CEIL) == min(300, CEIL)

--- a/tools/Python/PyDemo/tests/test_chart_scrollback.py
+++ b/tools/Python/PyDemo/tests/test_chart_scrollback.py
@@ -1,0 +1,104 @@
+"""Infinite scroll-back history: pure helpers + the compact-js_data payload patch.
+
+The scroll wiring itself needs the GUI, but the merge/paging math and the payload
+shrink are pure and testable here.
+"""
+
+import os
+import sys
+from datetime import datetime, timezone
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# Importing chart_window applies the compact-js_data patch (apply_patches()).
+from chart.chart_window import (  # noqa: E402
+    merge_older_bars, older_window, scroll_buffer_bars)
+
+
+def _bar(y, mo, d, h, m, s, close=1.0):
+    return {"time": datetime(y, mo, d, h, m, s, tzinfo=timezone.utc),
+            "open": close, "high": close, "low": close, "close": close, "volume": 1}
+
+
+# --- merge_older_bars --------------------------------------------------------
+
+def test_merge_prepends_and_counts():
+    existing = [_bar(2026, 6, 25, 0, 0, 20), _bar(2026, 6, 25, 0, 0, 30)]
+    older = [_bar(2026, 6, 25, 0, 0, 5), _bar(2026, 6, 25, 0, 0, 10)]
+    merged, prepended = merge_older_bars(existing, older)
+    assert prepended == 2
+    secs = [b["time"].second for b in merged]
+    assert secs == [5, 10, 20, 30]            # ascending, all present
+
+
+def test_merge_dedups_boundary_overlap():
+    existing = [_bar(2026, 6, 25, 0, 0, 20, close=2.0),
+                _bar(2026, 6, 25, 0, 0, 30, close=3.0)]
+    # older overlaps the boundary second (20) — must not duplicate it.
+    older = [_bar(2026, 6, 25, 0, 0, 10, close=1.0),
+             _bar(2026, 6, 25, 0, 0, 20, close=9.9)]
+    merged, prepended = merge_older_bars(existing, older)
+    assert [b["time"].second for b in merged] == [10, 20, 30]
+    assert prepended == 1                      # only second 10 is genuinely new
+    # existing bar wins the tie at second 20 (keeps the on-screen value).
+    assert merged[1]["close"] == 2.0
+
+
+def test_merge_empty_older_is_noop():
+    existing = [_bar(2026, 6, 25, 0, 0, 20)]
+    merged, prepended = merge_older_bars(existing, [])
+    assert prepended == 0
+    assert merged is existing
+
+
+# --- older_window ------------------------------------------------------------
+
+def test_older_window_steps_one_chunk_back():
+    oldest = datetime(2026, 6, 25, 9, 57, 0, tzinfo=timezone.utc)
+    start_dt, start_s, end_s = older_window(oldest, chunk_days=1)
+    assert end_s == "2026-06-25T09:57:00"
+    assert start_s == "2026-06-24T00:00:00"   # one day back, floored to 00:00
+    assert start_dt == datetime(2026, 6, 24, 0, 0, 0, tzinfo=timezone.utc)
+    assert start_dt.tzinfo is not None         # tz preserved for the next cursor
+
+
+def test_older_window_multiday_chunk():
+    oldest = datetime(2026, 6, 25, 12, 0, 0, tzinfo=timezone.utc)
+    start_dt, start_s, _ = older_window(oldest, chunk_days=3)
+    assert start_s == "2026-06-22T00:00:00"
+
+
+# --- scroll_buffer_bars (interval-scaled trigger) ----------------------------
+
+def test_scroll_buffer_scales_with_interval():
+    # 1-day look-ahead = one trading-ish day of bars at each interval.
+    assert scroll_buffer_bars(60, 1) == 1440      # 1m  -> 86400/60
+    assert scroll_buffer_bars(900, 1) == 96       # 15m -> 86400/900
+    assert scroll_buffer_bars(300, 1) == 288      # 5m  -> 86400/300
+
+
+def test_scroll_buffer_floor_applies_for_coarse_intervals():
+    # Daily bars: 1 bar/day * 1 day = 1, floored to 20 (JSDemo parity).
+    assert scroll_buffer_bars(86400, 1) == 20
+    assert scroll_buffer_bars(86400, 1, floor=5) == 5
+
+
+def test_scroll_buffer_honours_buffer_days():
+    assert scroll_buffer_bars(60, 2) == 2880      # two days of 1m bars
+    assert scroll_buffer_bars(60, 0) == 20        # 0 days -> floor
+
+
+# --- compact js_data patch ---------------------------------------------------
+
+def test_js_data_patch_is_compact():
+    import pandas as pd
+    import lightweight_charts.util as util
+    import lightweight_charts.abstract as abstract
+
+    df = pd.DataFrame([{"time": 1, "value": 2.0}, {"time": 2, "value": 3.0}])
+    out = util.js_data(df)
+    assert "\n" not in out                      # no indent=2 pretty-printing
+    assert abstract.js_data is util.js_data     # both bindings patched
+    # Still valid JSON with the expected records.
+    import json
+    assert json.loads(out) == [{"time": 1, "value": 2.0}, {"time": 2, "value": 3.0}]

--- a/tools/Python/PyDemo/tests/test_convert.py
+++ b/tools/Python/PyDemo/tests/test_convert.py
@@ -1,0 +1,64 @@
+"""Unit tests for chart.convert (pure NDateTime/Price -> chart-unit helpers)."""
+
+import os
+import sys
+from datetime import datetime, timezone
+
+import pytest
+
+# Make the PyDemo package importable when run from anywhere.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from t4login.datetime_.n_date_time import NDateTime  # noqa: E402
+from t4login.definitions.priceconversion.price import Price  # noqa: E402
+
+from chart import convert  # noqa: E402
+
+
+def test_epoch_ticks_constant_matches_ndatetime():
+    # The 1970 epoch expressed in NDateTime ticks must equal our constant.
+    assert NDateTime(1970, 1, 1).ticks == convert.EPOCH_TICKS
+
+
+def test_ndatetime_to_epoch_seconds():
+    ndt = NDateTime(2024, 1, 15, 9, 30, 0)
+    expected = int(datetime(2024, 1, 15, 9, 30, 0, tzinfo=timezone.utc).timestamp())
+    assert convert.ndatetime_to_epoch_seconds(ndt) == expected
+
+
+def test_ndatetime_to_datetime_roundtrip():
+    ndt = NDateTime(2024, 6, 18, 14, 5, 30)
+    dt = convert.ndatetime_to_datetime(ndt)
+    assert (dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second) == (
+        2024, 6, 18, 14, 5, 30,
+    )
+
+
+def test_tz_offset_applied():
+    ndt = NDateTime(2024, 1, 15, 9, 30, 0)
+    base = convert.ndatetime_to_epoch_seconds(ndt)
+    assert convert.ndatetime_to_epoch_seconds(ndt, tz_offset_hours=6) == base + 6 * 3600
+
+
+def test_price_to_float():
+    assert convert.price_to_float(Price("4525.50")) == pytest.approx(4525.50)
+    assert convert.price_to_float(Price(0)) == pytest.approx(0.0)
+
+
+def test_price_to_float_accepts_raw_types():
+    assert convert.price_to_float("3.14") == pytest.approx(3.14)
+    assert convert.price_to_float(None) != convert.price_to_float(None) or True  # nan
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("250@4525.50", (4525.50, 250)),
+        ("1@100", (100.0, 1)),
+        ("-", None),
+        ("", None),
+        ("garbage", None),
+    ],
+)
+def test_parse_trade_string(raw, expected):
+    assert convert.parse_trade_string(raw) == expected

--- a/tools/Python/PyDemo/tests/test_convert.py
+++ b/tools/Python/PyDemo/tests/test_convert.py
@@ -47,8 +47,8 @@ def test_price_to_float():
 
 def test_price_to_float_accepts_raw_types():
     assert convert.price_to_float("3.14") == pytest.approx(3.14)
-    assert convert.price_to_float(None) != convert.price_to_float(None) or True  # nan
-
+    import math
+    assert math.isnan(convert.price_to_float(None))
 
 @pytest.mark.parametrize(
     "raw,expected",

--- a/tools/Python/PyDemo/tests/test_history.py
+++ b/tools/Python/PyDemo/tests/test_history.py
@@ -1,0 +1,88 @@
+"""Unit tests for chart.history JSON parsing / scale calibration / interval map.
+
+Network paths (binary/JSON fetch) are not exercised here; only the pure parsing
+and mapping helpers are.
+"""
+
+import os
+import sys
+from datetime import timezone
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from chart import history  # noqa: E402
+
+
+def test_interval_to_t4_table():
+    assert history.interval_to_t4(15) == ("Second", 15)
+    assert history.interval_to_t4(60) == ("Minute", 1)
+    assert history.interval_to_t4(300) == ("Minute", 5)
+    assert history.interval_to_t4(3600) == ("Hour", 1)
+    assert history.interval_to_t4(86400) == ("Day", 1)
+
+
+def test_interval_to_t4_derived():
+    assert history.interval_to_t4(120) == ("Minute", 2)
+    assert history.interval_to_t4(7200) == ("Hour", 2)
+    assert history.interval_to_t4(45) == ("Second", 45)
+
+
+def test_calibrate_scale_power_of_ten():
+    assert history.calibrate_scale(5800000.0, 5800.0) == 1000.0
+    assert history.calibrate_scale(5800.0, 5800.0) == 1.0
+
+
+def test_calibrate_scale_implausible_returns_none():
+    assert history.calibrate_scale(5800000000000.0, 5800.0) is None  # exp > 8
+    assert history.calibrate_scale(0, 5800.0) is None
+
+
+def _parse(rows, live_price=None):
+    # _parse_json_bars is an instance method but uses no instance state beyond tz;
+    # build a bare object to call it without constructing a ChartClient.
+    obj = history.ChartHistory.__new__(history.ChartHistory)
+    obj._tz = 0.0
+    return obj._parse_json_bars(rows, live_price)
+
+
+def test_parse_json_bars_basic():
+    rows = [
+        {"time": "2024-01-15T09:30:00", "openPrice": 100, "highPrice": 110,
+         "lowPrice": 95, "closePrice": 105, "volume": 50},
+        {"time": "2024-01-15T09:31:00", "openPrice": 105, "highPrice": 108,
+         "lowPrice": 104, "closePrice": 107, "volume": 20},
+    ]
+    bars = _parse(rows)
+    assert len(bars) == 2
+    assert bars[0]["open"] == 100.0
+    assert bars[0]["close"] == 105.0
+    assert bars[0]["volume"] == 50
+    assert bars[0]["time"].tzinfo == timezone.utc
+    assert bars[0]["time"].hour == 9 and bars[0]["time"].minute == 30
+
+
+def test_parse_json_bars_applies_calibration():
+    rows = [
+        {"time": "2024-01-15T09:30:00", "openPrice": 5800000, "highPrice": 5810000,
+         "lowPrice": 5790000, "closePrice": 5805000, "volume": 1},
+    ]
+    bars = _parse(rows, live_price=5805.0)
+    assert bars[0]["close"] == 5805.0
+    assert bars[0]["open"] == 5800.0
+
+
+def test_parse_json_bars_wrapped_in_dict_key():
+    raw = {"bars": [
+        {"time": "2024-01-15T09:30:00", "open": 1, "high": 2, "low": 0.5,
+         "close": 1.5, "volume": 3},
+    ]}
+    obj = history.ChartHistory.__new__(history.ChartHistory)
+    obj._tz = 0.0
+    bars = obj._parse_json_bars(raw, None)
+    assert len(bars) == 1
+    assert bars[0]["high"] == 2.0
+
+
+def test_parse_json_bars_empty():
+    assert _parse([]) == []
+    assert _parse({"unexpected": 1}) == []

--- a/tools/Python/PyDemo/tests/test_indicators.py
+++ b/tools/Python/PyDemo/tests/test_indicators.py
@@ -1,0 +1,71 @@
+"""Unit tests for chart.features.indicators pure math (sma/ema/vwap)."""
+
+import os
+import sys
+from datetime import datetime, timezone, timedelta
+
+import pandas as pd
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from chart.features import indicators as ind  # noqa: E402
+
+
+def _df(closes, vols=None, day=15):
+    base = datetime(2024, 1, day, 9, 30, tzinfo=timezone.utc)
+    n = len(closes)
+    vols = vols or [1] * n
+    return pd.DataFrame({
+        "time": [base + timedelta(minutes=i) for i in range(n)],
+        "open": closes, "high": [c + 1 for c in closes],
+        "low": [c - 1 for c in closes], "close": closes, "volume": vols,
+    })
+
+
+def test_sma_basic():
+    s = ind.sma(pd.Series([1, 2, 3, 4, 5], dtype=float), 3)
+    assert pd.isna(s.iloc[0]) and pd.isna(s.iloc[1])
+    assert s.iloc[2] == pytest.approx(2.0)
+    assert s.iloc[4] == pytest.approx(4.0)
+
+
+def test_ema_seed_and_trend():
+    s = ind.ema(pd.Series([10, 10, 10, 10], dtype=float), 3)
+    # Constant input -> EMA equals the constant.
+    assert all(v == pytest.approx(10.0) for v in s)
+
+
+def test_vwap_no_reset_single_day():
+    df = _df([10, 20, 30], vols=[1, 1, 2])
+    v = ind.vwap(df, day_reset=True)
+    # cumulative: tp≈close here (high/low symmetric): (10*1)/(1)=10;
+    # (10+20)/(2)=15; (10+20+60)/(4)=22.5
+    assert v.iloc[0] == pytest.approx(10.0)
+    assert v.iloc[1] == pytest.approx(15.0)
+    assert v.iloc[2] == pytest.approx(22.5)
+
+
+def test_vwap_day_reset():
+    d1 = _df([10, 20], vols=[1, 1], day=15)
+    d2 = _df([100, 200], vols=[1, 1], day=16)
+    df = pd.concat([d1, d2], ignore_index=True)
+    v = ind.vwap(df, day_reset=True)
+    # Day 2 restarts: first point of day2 == its own typical price (100).
+    assert v.iloc[2] == pytest.approx(100.0)
+    assert v.iloc[3] == pytest.approx(150.0)
+
+
+def test_vwap_zero_volume_no_div_zero():
+    df = _df([10, 20], vols=[0, 0])
+    v = ind.vwap(df)
+    assert v.isna().all()
+
+
+def test_compute_dispatch():
+    df = _df([1, 2, 3, 4, 5])
+    assert ind.compute(df, "sma", 2).iloc[-1] == pytest.approx(4.5)
+    assert not ind.compute(df, "ema", 3).isna().any()
+    assert ind.compute(df, "vwap", None).iloc[0] == pytest.approx(1.0)
+    with pytest.raises(ValueError):
+        ind.compute(df, "bogus", None)

--- a/tools/Python/PyDemo/tests/test_order_tools.py
+++ b/tools/Python/PyDemo/tests/test_order_tools.py
@@ -1,0 +1,89 @@
+"""Unit tests for OrderTools handler routing (no chart/window needed)."""
+
+import os
+import sys
+import asyncio
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from chart.features.order_tools import OrderTools  # noqa: E402
+
+
+class _FakeClient:
+    def __init__(self):
+        self.calls = []
+
+    async def submit_order(self, side, vol, price, pt):
+        self.calls.append(("submit", side, vol, float(price), pt))
+
+    async def pull_order(self, uid):
+        self.calls.append(("pull", uid))
+
+
+class _FakeBridge:
+    def run_coro(self, factory):
+        asyncio.run(factory())
+
+    def guard(self, fn):
+        return fn
+
+
+def _tools(orders=None, last=108.0, vol=2):
+    client = _FakeClient()
+    ot = OrderTools(None, _FakeBridge(), client,
+                    order_provider=lambda: orders or {},
+                    last_price_provider=lambda: last,
+                    default_volume=vol)
+    return ot, client
+
+
+def test_context_buy_sell():
+    ot, client = _tools()
+    ot._on_context_action("buy", "105.0")
+    ot._on_context_action("sell", "111.0")
+    assert ("submit", "buy", 2, 105.0, "limit") in client.calls
+    assert ("submit", "sell", 2, 111.0, "limit") in client.calls
+
+
+def test_cancel_nearest():
+    ot, client = _tools(orders={"o1": 105.0, "o2": 120.0})
+    ot._on_context_action("cancel", "104.9")
+    assert ("pull", "o1") in client.calls
+
+
+def test_cancel_nearest_no_orders():
+    ot, client = _tools(orders={})
+    ot._on_context_action("cancel", "100")
+    assert client.calls == []
+
+
+def test_click_mode_gating():
+    ot, client = _tools()
+    ot.set_click_mode(False)  # set_click_mode without chart no-ops the run_script (chart=None)
+    ot._click_mode = False    # ensure off (set_click_mode logged exception but set flag)
+    ot.on_click(None, None, 100.0)
+    assert client.calls == []
+    ot._click_mode = True
+    ot.on_click(None, None, 100.0)   # 100 < 108 -> buy
+    assert ("submit", "buy", 2, 100.0, "limit") in client.calls
+
+
+def test_infer_side_by_last_price():
+    ot, _ = _tools(last=108.0)
+    assert ot._infer_side(100.0) == "buy"    # below market
+    assert ot._infer_side(120.0) == "sell"   # above market
+
+
+def test_drag_uses_release_price():
+    ot, client = _tools(last=108.0)
+    ot._on_drag("100", "115.0")   # release 115 > 108 -> sell
+    assert ("submit", "sell", 2, 115.0, "limit") in client.calls
+
+
+def test_mode_toggle():
+    ot, _ = _tools()
+    ot._click_mode = False
+    ot._on_mode("click")
+    assert ot._click_mode is True
+    ot._on_mode("click")
+    assert ot._click_mode is False

--- a/tools/Python/algo-py/.gitignore
+++ b/tools/Python/algo-py/.gitignore
@@ -1,0 +1,11 @@
+__pycache__/
+*.pyc
+.venv/
+venv/
+
+# Regenerated study artifacts (charts + report) — reproduce via the run_*.py
+# scripts. Covers every output variant (output/, output_pairs/, output_portfolio/…).
+research/output*/
+
+# User-provided market data (not committed); keep the folder's README.
+research/data_csv/*.csv

--- a/tools/Python/algo-py/README.md
+++ b/tools/Python/algo-py/README.md
@@ -1,0 +1,76 @@
+# algo-py — ES combo-signal research/backtest study (June 2025 US–Iran war)
+
+An **offline research/backtest** deliverable (no live trading). It
+decodes T4 binary chart history, computes **momentum + mean-reversion** signals
+on **ES**, applies a **rules-based conditional weighting driven by oil (CL) and
+gold (GC)**, and analyzes the combined model through the June 2025 "12-Day War"
+(≈Jun 13 → Jun 25). Output: charts + a Markdown report in `research/output/`.
+
+The model only *decides* on ES; weights shift toward mean-reversion and trim
+exposure when oil and gold spike together (the geopolitical-stress tell). It is
+**calibrated on the ~1 year before** the war and **evaluated** on the war window —
+nothing is fit on the event itself (a ~2-week event is one observation; tuning on
+it would overfit). All knobs live in `research/config.py`.
+
+## Setup
+
+```bash
+cd algo-py                              # tools/Python/algo-py
+pip install -r requirements.txt
+pip install -e ../t4-Python-api   # sibling package; provides the `t4login` chart client
+```
+
+## Run — CSV source (default)
+
+CSV is the default, token-free source — convenient for offline iteration. Drop
+one OHLCV file per instrument into `research/data_csv/` (`es.csv`, `cl.csv`,
+`gc.csv` — see that folder's README for the format), then:
+
+```bash
+python -m research.run_study                       # --source csv is the default
+python -m research.run_study --csv-dir /some/dir   # files elsewhere
+```
+
+Output → `research/output/` (`report.md` + PNGs).
+
+## T4 source (live data)
+
+The conversion repo has no login flow, so you supply a bearer token from an
+authenticated T4 session, then run the probe gate:
+
+```bash
+export T4_API_TOKEN=...           # PowerShell: $env:T4_API_TOKEN = "..."
+python -m research.probe_data     # GO / NO-GO coverage check
+python -m research.run_study --source t4            # daily
+python -m research.run_study --source t4 --intraday # minute (if retained)
+```
+
+The barchart calls fetch **volume-continuation** bars
+(`continuationType=Volume` — the only value the endpoint supports; `marketID`
+is omitted, which is valid with a continuation type). Equity-index futures use
+the `CME_Eq` exchange id (with `CME_E`/`CME` as ordered fallbacks). If a symbol
+comes back NO-GO from the probe, adjust its `exchange_candidates` in
+`config.SYMBOLS` to the spelling the probe table reports.
+
+> From the JSDemo UI you don't need the manual `export`: the **Portfolio Study**
+> panel forwards the browser's live JWT to the server, which sets `T4_API_TOKEN`
+> for the spawned study process — just Connect, pick **Source: T4**, and Run.
+
+## research/ layout
+
+| File | Purpose |
+|------|---------|
+| `config.py` | All knobs: dates, instruments, indicator/regime params, ES cost model. |
+| `probe_data.py` | **Step 0** auth/symbol/retention/resolution check → GO/NO-GO. |
+| `data.py` | Fetch + binary-decode ES/CL/GC via `ChartClient`; align to a common index. |
+| `indicators.py` | Pure indicators: ROC, RSI, MACD, MA-slope, z-score. |
+| `model.py` | Rules-based combo: oil/gold regime → conditional weights → ES target. |
+| `backtest.py` | Vectorized backtest (1-bar-lag, costs) → equity, trades, stats. |
+| `report.py` | matplotlib charts + Markdown report with caveats. |
+| `run_study.py` | Orchestrates fetch → model → backtest → report. |
+
+## Caveats (also written into every report)
+
+Single event = illustrative **case study, not statistical validation**; nothing
+fit on the window; weights are transparent defaults, not optimised; costs are
+modelled approximations; daily-only data hides intraday strike dynamics.

--- a/tools/Python/algo-py/requirements.txt
+++ b/tools/Python/algo-py/requirements.txt
@@ -1,0 +1,14 @@
+# Research study (research/) — backtest + report
+pandas>=2.0
+numpy>=1.24
+matplotlib>=3.7
+# Free, real OHLCV for `--source yahoo` (research only; the live bridge and the
+# csv/t4 paths don't need it).
+yfinance>=0.2
+# Cointegration test (Engle-Granger) for the market-neutral pairs study.
+statsmodels>=0.14
+# The research module also needs the T4 chart client `t4login`. Install the
+# decoder package in editable mode (it has its own pyproject.toml). It lives
+# next to this folder under tools/Python/:
+#   pip install -e ../t4-Python-api
+# (path is relative to this algo-py/ folder)

--- a/tools/Python/algo-py/research/FINDINGS.md
+++ b/tools/Python/algo-py/research/FINDINGS.md
@@ -1,0 +1,119 @@
+# Research findings — "a strategy that profits most weeks and wins"
+
+A record of what we tested, on **real market data**, in pursuit of a strategy with a high
+**weekly win rate**, and where it led. Short version up front, evidence below.
+
+## TL;DR
+
+- **Nothing we built beats simply holding the market on weekly win rate.** A broad equity
+  index is green in **~57% of weeks** for free. None of the added machinery (rotation,
+  market-neutral pairs, divergence stops, scaling to 80 names) raised that — most lowered it
+  or lost money.
+- **"Profit every week and win" is not a real target.** Anything that appears to do it is
+  hiding tail risk. The honest target is *a high fraction of winning weeks with a bounded
+  worst week* — and on liquid US equities that bar is set by buy & hold itself.
+- **Cross-sector pairs trading failed out-of-sample.** Historical cointegration is largely
+  spurious; the relationships break in the live window. Scaling to more pairs made it *worse*,
+  not better (shared selection bias, not independent bets).
+- **The one defensible edge we found is risk reduction, not weekly income:** a simple
+  **trend overlay** (hold SPY above its 200-day average, else go to cash) cut max drawdown by
+  roughly a third and raised Sharpe, for ~2 points less CAGR. It does **not** win more weeks —
+  it makes the bad stretches shallower.
+
+## Data & method
+
+- **Source:** real daily OHLCV from Yahoo Finance (`research/data.py:fetch_yahoo_*`), adjusted.
+  The original `data_csv/*.csv` were **synthetic** (e.g. SPY ≈ $300 in 2021 vs the real ~$368) —
+  all results here are on genuine data, cached to `data_csv/`.
+- **Discipline:** parameters/pairs are selected in-sample and evaluated **out-of-sample** (never
+  fit on the evaluation window).
+- **Weekly lens:** `multi_backtest.weekly_consistency()` measures % of *active* weeks that win,
+  average win vs loss week, worst week, and longest losing streak. (An early version counted
+  flat warm-up / out-of-market weeks as losses — producing a fake "57-week losing streak"; fixed
+  to judge active weeks only.)
+
+## Results across everything tested
+
+| Strategy | Window | Return / CAGR | % winning weeks | Worst week | Max DD | SPY corr |
+|---|---|---|---|---|---|---|
+| **Buy & hold (the benchmark)** | — | reference | **~57%** | −14.6% | −33.7% | 1.0 |
+| Momentum/value rotation (full invest) | 2018–25 | +9.2% | 59.3%¹ | — | small² | high |
+| Cross-sector pairs (4) | 2022–25 | −7.1% | 44.4% | −2.1% | −10.1% | 0.04 |
+| Cross-sector pairs (4) + divergence stop | 2022–25 | −5.4% | 46.1% | −2.1% | −8.9% | 0.06 |
+| Large universe pairs (15) + stop | 2022–25 | −8.7% | 47.0% | −2.5% | −11.2% | −0.11 |
+| Tethered pair V–MA + stop | 2022–25 | +2.0% | 54.5% | −0.35% | −1.4% | 0.08 |
+| **Trend overlay (SPY, 200-day)** | 2018–25 | +12.3% CAGR | 46.0%³ | −12.0% | **−22.6%** | ~1.0 |
+
+¹ Rotation's ~59% is essentially the market's own weekly cadence — it *is* equity beta.
+² Rotation drawdown looks tiny only because it deploys little capital (gross_target ≈ 1.0).
+³ Overlay wins *fewer* weeks than buy & hold because it sits in cash ~31% of the time; its win
+  rate among invested weeks is market-like. Its value is the drawdown column, not this one.
+(Pair win-rates are over *active* weeks; pair returns are over the 2022–25 OOS window.)
+
+## Why the pairs idea failed (the interesting part)
+
+The thesis — instruments that look unrelated (fast food / tech / commerce) but co-move under
+macro shifts — is appealing, and the cointegration filter *did* surface exactly those pairs
+(GOOGL–UNH, CMG–WMT, MSFT–JNJ, WMT–V…). But out-of-sample they **lost money**, for a structural
+reason:
+
+- **In-sample cointegration is mostly spurious.** Ranking thousands of pairs and keeping the few
+  with the lowest historical p-value selects *statistical flukes*, not durable economic links.
+- **Cross-sector pairs have no economic tether,** so nothing pulls a diverged spread back. The
+  clearest example: **GOOGL–UNH** tracked tightly through 2024, then UnitedHealth collapsed
+  (~120→60 in 2025) while Google held — the spread blew out past z = 4 and never reverted. Being
+  short that spread just bled.
+- **Scaling made it worse.** 15 pairs lost more than 4, because the bets weren't independent —
+  they shared one hidden common cause (selection on a spurious fit) and failed together. The
+  divergence stop trimmed the bleed but never turned it positive.
+- **What *did* hold up was the lone same-sector pair, V–MA** (two card networks with a real
+  economic link): +2%, market-neutral, −0.35% worst week. Robust pairs need a tether — which
+  usually means they *do* look correlated on the surface, the opposite of the original idea.
+
+## The defensible pivot: risk-adjusted growth, not weekly wins
+
+`research/run_overlay_study.py` — SPY held while above its 200-day SMA, otherwise to cash
+(time-series momentum / Faber, the most-replicated tactical rule). Over 2018–2025 on real SPY:
+
+| metric | trend overlay | buy & hold |
+|---|---|---|
+| CAGR | +12.3% | +14.3% |
+| Sharpe | **0.88** | 0.76 |
+| Max drawdown | **−22.6%** | −33.7% |
+| Worst week | −12.0% | −14.6% |
+| Time in market | 68.8% | 100% |
+
+It trades ~2 points of CAGR for a **one-third cut in max drawdown** and a higher Sharpe — by
+sitting out sustained downtrends (flat in cash through 2022 and near the 2020 bottom). This is a
+genuine, well-documented edge — but it is **risk reduction**, not a weekly-income engine; it
+wins fewer weeks, just loses less in the bad ones. Caveats: whipsaws in choppy markets, lags the
+turn, tax-inefficient, and is one rule on one asset over one history.
+
+## How to reproduce
+
+From `tools/Python/algo-py/` (`pip install -r requirements.txt` first):
+
+```bash
+# Trend overlay (the defensible result)
+python -m research.run_overlay_study --source csv --sma 200      # SPY is cached
+python -m research.run_overlay_study --source yahoo --sma 200 --below 0.5
+
+# Market-neutral pairs (the negative result)
+python -m research.run_pairs_study --source yahoo --cache-csv --calib-end 2021-12-31   # ~24-name universe
+python -m research.run_pairs_study --source csv --universe large --top-pairs 15        # 80-name universe
+python -m research.run_pairs_study --source csv --min-corr 0.7                          # tethered (V–MA)
+
+# Rotation + weekly lens
+python -m research.run_portfolio_study --source csv --gross-target 2.0 --max-contracts 100
+```
+
+Each writes a `report.md` + charts under its own `research/output_*/` directory.
+
+## Bottom line
+
+If the goal is *winning most weeks*, the answer is **buy and hold a broad index** — ~57% of weeks
+green, zero machinery, hard to beat. If the goal is *a smoother ride for similar growth*, add a
+**trend overlay** to cut the deep drawdowns. The complexity we explored (rotation, pairs,
+shorts, stops, scale) did not add a weekly-consistency edge on liquid US equities — and the
+investigation is more valuable for ruling those out cleanly than any of them would have been if
+we'd shipped it on faith.

--- a/tools/Python/algo-py/research/__init__.py
+++ b/tools/Python/algo-py/research/__init__.py
@@ -1,0 +1,2 @@
+"""Research study: ES combo signal (momentum + mean-reversion, oil/gold-weighted)
+over the June 2025 US-Iran war window. See README.md."""

--- a/tools/Python/algo-py/research/backtest.py
+++ b/tools/Python/algo-py/research/backtest.py
@@ -1,0 +1,151 @@
+"""
+research/backtest.py
+
+Vectorized backtest of an ES target-position series. Deliberately simple and
+auditable:
+
+  * target in [-1, 1] → integer contracts = round(target * max_contracts)
+  * positions are applied with a ONE-BAR LAG (act on the next bar's move) so
+    there is no look-ahead — same anti-look-ahead stance as the JS SimBroker.
+  * per-bar PnL = position_held * Δprice * point_value, minus commission +
+    slippage on every contract that changes hands.
+
+Returns an equity curve, a trade blotter, and summary stats, plus an ES
+buy-&-hold baseline. A reconciliation assert guarantees Σ per-bar PnL equals the
+equity delta.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+import pandas as pd
+
+from . import config
+
+
+@dataclass
+class BacktestResult:
+    equity: pd.Series          # cumulative PnL ($) including starting cash
+    pnl: pd.Series             # per-bar PnL ($)
+    positions: pd.Series       # contracts held into each bar
+    trades: pd.DataFrame       # one row per position change
+    stats: dict
+    buy_hold_equity: pd.Series
+
+
+def _annualization(index: pd.DatetimeIndex) -> float:
+    """Bars per year, inferred from median spacing (daily→~252, minute→~98k)."""
+    if len(index) < 3:
+        return 252.0
+    secs = np.median(np.diff(index.values).astype("timedelta64[s]").astype(float))
+    if secs <= 0:
+        return 252.0
+    bars_per_day = max(1.0, 86400.0 / secs)
+    # Trading days ≈ 252; for intraday assume ~6.5h sessions.
+    if bars_per_day > 1.5:
+        return 252.0 * (6.5 * 3600.0 / secs)
+    return 252.0
+
+
+def _stats(pnl: pd.Series, equity: pd.Series, positions: pd.Series,
+           trades: pd.DataFrame, ann: float, starting_cash: float) -> dict:
+    total = float(pnl.sum())
+    rets = pnl / starting_cash
+    sharpe = 0.0
+    if rets.std(ddof=0) > 0:
+        sharpe = float(np.sqrt(ann) * rets.mean() / rets.std(ddof=0))
+    running_max = equity.cummax()
+    drawdown = equity - running_max
+    max_dd = float(drawdown.min())
+    closed = trades[trades["realized_pnl"].notna()]
+    wins = closed[closed["realized_pnl"] > 0]["realized_pnl"]
+    losses = closed[closed["realized_pnl"] < 0]["realized_pnl"]
+    hit = float(len(wins) / len(closed)) if len(closed) else 0.0
+    pf = float(wins.sum() / -losses.sum()) if losses.sum() != 0 else float("inf")
+    return {
+        "net_pnl": total,
+        "return_pct": float(total / starting_cash * 100.0),
+        "sharpe": sharpe,
+        "max_drawdown": max_dd,
+        "max_drawdown_pct": float(max_dd / starting_cash * 100.0),
+        "n_bars": int(len(pnl)),
+        "n_trades": int(len(closed)),
+        "hit_rate": hit,
+        "profit_factor": pf,
+        "time_in_market_pct": float((positions != 0).mean() * 100.0),
+    }
+
+
+def backtest(prices: pd.Series, target: pd.Series, cfg: config.StudyConfig = config.DEFAULT) -> BacktestResult:
+    c = cfg.costs
+    prices = prices.astype(float)
+    target = target.reindex(prices.index).fillna(0.0).clip(-1.0, 1.0)
+
+    # Desired contracts, then lag one bar so today's signal trades tomorrow.
+    desired = (target * c.max_contracts).round().astype(int)
+    positions = desired.shift(1).fillna(0).astype(int)
+
+    dprice = prices.diff().fillna(0.0)
+    gross_pnl = positions * dprice * c.point_value
+
+    # Costs when the held position changes (contracts traded * per-contract cost).
+    pos_change = positions.diff().fillna(positions).abs()
+    cost = pos_change * (c.commission + c.slippage_pts * c.point_value)
+
+    pnl = (gross_pnl - cost)
+    equity = c.starting_cash + pnl.cumsum()
+
+    # Trade blotter: realised PnL booked when a position closes/flips/reduces.
+    trades = _build_trades(positions, prices, c)
+
+    ann = _annualization(prices.index)
+    stats = _stats(pnl, equity, positions, trades, ann, c.starting_cash)
+
+    # Buy & hold 1 contract for baseline.
+    bh_pnl = dprice * c.point_value
+    buy_hold = c.starting_cash + bh_pnl.cumsum()
+
+    # Reconciliation: equity delta must equal summed PnL (within fp tolerance).
+    assert abs((equity.iloc[-1] - c.starting_cash) - pnl.sum()) < 1e-6, "PnL reconciliation failed"
+
+    return BacktestResult(
+        equity=equity, pnl=pnl, positions=positions,
+        trades=trades, stats=stats, buy_hold_equity=buy_hold,
+    )
+
+
+def _build_trades(positions: pd.Series, prices: pd.Series, c: config.CostModel) -> pd.DataFrame:
+    """Track average entry and realise PnL on reductions/flips. One row per
+    position change; `realized_pnl` is NaN for pure opens/adds."""
+    rows = []
+    held = 0
+    avg = 0.0
+    prev = 0
+    for ts, pos in positions.items():
+        price = float(prices.loc[ts])
+        if pos == prev:
+            continue
+        delta = pos - prev
+        realized = np.nan
+        if prev == 0 or (prev > 0 and delta > 0) or (prev < 0 and delta < 0):
+            # opening or adding in the same direction → update avg cost
+            new_held = prev + delta
+            avg = (avg * abs(prev) + price * abs(delta)) / max(1, abs(new_held))
+            held = new_held
+        else:
+            # reducing, closing, or flipping → realise on the closed portion
+            closing = min(abs(delta), abs(prev))
+            direction = 1 if prev > 0 else -1
+            realized = direction * (price - avg) * closing * c.point_value
+            held = prev + delta
+            if (prev > 0) != (held > 0) and held != 0:
+                avg = price  # flipped: remaining is a fresh position at this price
+            elif held == 0:
+                avg = 0.0
+        rows.append({"ts": ts, "from": prev, "to": pos, "price": price, "realized_pnl": realized})
+        prev = pos
+    return pd.DataFrame(rows).set_index("ts") if rows else pd.DataFrame(
+        columns=["from", "to", "price", "realized_pnl"]
+    )

--- a/tools/Python/algo-py/research/config.py
+++ b/tools/Python/algo-py/research/config.py
@@ -1,0 +1,338 @@
+"""
+research/config.py
+
+Single place to adjust everything the study depends on: the war window, the
+~1-year calibration span, the instruments, indicator/regime parameters, and the
+ES cost model. No logic here — just the knobs.
+
+The dates encode the June 2025 "12-Day War": Israel struck Iran ~Jun 13 2025,
+the US struck nuclear sites ~Jun 21-22, ceasefire ~Jun 24. We CALIBRATE on the
+~year before the event and only EVALUATE on the event window (never fit on it).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, replace
+from typing import List, Tuple
+
+
+# --- Dates -------------------------------------------------------------------
+# Event (the war) — evaluated, never fit.
+EVENT_START = "2025-06-13"
+EVENT_END = "2025-06-25"
+
+# Calibration: the ~1 year BEFORE the event. Indicator lookbacks & regime
+# thresholds are derived from this span only.
+CALIB_START = "2024-06-01"
+CALIB_END = "2025-06-12"
+
+# Full fetch span (calibration + event + a little tail for context).
+FETCH_START = "2024-06-01"
+FETCH_END = "2025-06-30"
+
+
+# --- Instruments -------------------------------------------------------------
+# T4 identifies a market by (exchange_id, contract_id) and an optional market_id
+# (a specific contract month). Exchange-id spellings vary (the repo's tests use
+# "CME_E"/"YM"), so each symbol lists CANDIDATE exchange ids — probe_data.py
+# tries them in order and reports which one actually returns data.
+@dataclass(frozen=True)
+class Symbol:
+    key: str                      # short label used in DataFrame columns: es/cl/gc
+    name: str
+    contract_id: str
+    exchange_candidates: List[str]
+    # continuationType gives a continuous (volume-rolled) series so we don't have
+    # to hand-roll futures roll across the multi-month window. "Volume" is the
+    # ONLY value the T4 barchart endpoint accepts (the docs + the conversion
+    # repo's working integration test confirm it; "Continuous" returns HTTP 400).
+    continuation_type: str = "Volume"
+    # Yahoo Finance ticker for the free `--source yahoo` path. If unset, falls
+    # back to the contract_id (ETFs trade under their plain symbol) or, for
+    # futures (point_value >= 5), the contract_id + "=F" continuous front-month.
+    yahoo: str = ""
+
+    @property
+    def yahoo_ticker(self) -> str:
+        if self.yahoo:
+            return self.yahoo
+        # Futures vs share: POINT_VALUES is defined below; default to >=5 = future.
+        if POINT_VALUES.get(self.key, 1.0) >= 5.0:
+            return f"{self.contract_id}=F"
+        return self.contract_id
+
+
+# Equity-index futures lead with "CME_Eq" — the spelling JSDemo's working config
+# uses for ES — then fall back to "CME_E"/"CME" (fetch_symbol tries each in turn).
+ES = Symbol("es", "E-mini S&P 500", "ES", ["CME_Eq", "CME_E", "CME"])
+CL = Symbol("cl", "Crude Oil (WTI)", "CL", ["NYMEX", "CME_NYMEX", "CME"])
+GC = Symbol("gc", "Gold", "GC", ["COMEX", "CME_COMEX", "CME"])
+
+SYMBOLS = [ES, CL, GC]
+
+
+# --- Portfolio basket (the slow-rebuild rotation study) ----------------------
+# The rotation study trades a BASKET of equity-index "stock trackers". Two
+# parallel definitions of the same exposures:
+#
+#   * ETFs  — for the CSV/Yahoo research path (the default, no token needed).
+#             Drop spy.csv / qqq.csv / dia.csv / iwm.csv into research/data_csv/.
+#             ETFs trade as shares, so point_value = 1.
+#   * Futures — for the live T4 path (volume-continuation bars). Same index
+#             exposures, but exchange point values differ (see POINT_VALUES).
+#
+# The `key` is what names the CSV file and the DataFrame column prefix, so keep
+# ETF keys (spy/qqq/...) and futures keys (es/nq/...) distinct.
+SPY = Symbol("spy", "SPDR S&P 500 ETF", "SPY", ["ARCA", "NYSE"])
+QQQ = Symbol("qqq", "Invesco QQQ (Nasdaq-100)", "QQQ", ["NASDAQ"])
+DIA = Symbol("dia", "SPDR Dow Jones ETF", "DIA", ["ARCA", "NYSE"])
+IWM = Symbol("iwm", "iShares Russell 2000 ETF", "IWM", ["ARCA", "NYSE"])
+EQUITY_INDEX_ETFS = [SPY, QQQ, DIA, IWM]
+
+NQ = Symbol("nq", "E-mini Nasdaq-100", "NQ", ["CME_Eq", "CME_E", "CME"])
+YM = Symbol("ym", "E-mini Dow", "YM", ["CBOT", "CME_CBOT", "CME"])
+RTY = Symbol("rty", "E-mini Russell 2000", "RTY", ["CME_Eq", "CME_E", "CME"])
+EQUITY_INDEX_FUTURES = [ES, NQ, YM, RTY]
+
+# The basket the rotation study trades. Default to ETFs (CSV is the default,
+# token-free source). Swap to EQUITY_INDEX_FUTURES for the live T4 path.
+BASKET = EQUITY_INDEX_ETFS
+
+# Dollar value of a 1.0 price move for one unit (share/contract). ETFs = $1.
+POINT_VALUES = {
+    "spy": 1.0, "qqq": 1.0, "dia": 1.0, "iwm": 1.0,   # ETF shares
+    "es": 50.0, "nq": 20.0, "ym": 5.0, "rty": 50.0,   # equity-index futures
+    "cl": 1000.0, "gc": 100.0,                          # diversifiers (war study)
+}
+
+
+# --- Pairs-trading universe (market-neutral cross-sector study) ---------------
+# A deliberately MIXED universe — single names across unrelated sectors plus a
+# few sector ETFs — so the pair-finder can discover cross-sector spreads that
+# co-move under macro shifts (the user's "fast food + tech + commerce" idea).
+# All trade as shares, so point_value = 1. yahoo ticker defaults to contract_id.
+_PAIRS_SPEC = [
+    # key,  name,                       ticker
+    ("mcd",  "McDonald's",              "MCD"),
+    ("sbux", "Starbucks",               "SBUX"),
+    ("cmg",  "Chipotle",                "CMG"),
+    ("yum",  "Yum! Brands",             "YUM"),
+    ("aapl", "Apple",                   "AAPL"),
+    ("msft", "Microsoft",               "MSFT"),
+    ("nvda", "NVIDIA",                  "NVDA"),
+    ("googl","Alphabet",                "GOOGL"),
+    ("amzn", "Amazon",                  "AMZN"),
+    ("wmt",  "Walmart",                 "WMT"),
+    ("cost", "Costco",                  "COST"),
+    ("hd",   "Home Depot",              "HD"),
+    ("jpm",  "JPMorgan",                "JPM"),
+    ("v",    "Visa",                    "V"),
+    ("ma",   "Mastercard",              "MA"),
+    ("xom",  "Exxon Mobil",             "XOM"),
+    ("jnj",  "Johnson & Johnson",       "JNJ"),
+    ("unh",  "UnitedHealth",            "UNH"),
+    ("xlk",  "Tech Select Sector ETF",  "XLK"),
+    ("xly",  "Cons. Discr. Sector ETF", "XLY"),
+    ("xlp",  "Cons. Staples Sector ETF","XLP"),
+    ("xlf",  "Financials Sector ETF",   "XLF"),
+    ("xle",  "Energy Sector ETF",       "XLE"),
+    ("xrt",  "Retail ETF",              "XRT"),
+]
+PAIRS_UNIVERSE = [Symbol(k, n, t, ["ARCA", "NASDAQ", "NYSE"], yahoo=t) for k, n, t in _PAIRS_SPEC]
+POINT_VALUES.update({s.key: 1.0 for s in PAIRS_UNIVERSE})  # all trade as shares
+
+# Large universe (~80 liquid large caps + sector ETFs) for the scaled pairs study:
+# more names ⇒ the cointegration filter yields MANY tethered pairs, and holding a
+# diversified basket of independent spreads smooths the week-to-week P&L (any one
+# pair's edge is tiny; the consistency only shows up at scale). Tickers only —
+# key = lowercase ticker, all trade as shares.
+_LARGE_TICKERS = [
+    # Tech / semis / software
+    "AAPL", "MSFT", "NVDA", "GOOGL", "META", "ADBE", "CRM", "ORCL", "CSCO",
+    "INTC", "AMD", "QCOM", "TXN", "AVGO", "IBM", "ACN", "AMAT", "MU",
+    # Communications / media
+    "NFLX", "DIS", "CMCSA", "T", "VZ",
+    # Consumer discretionary / retail
+    "AMZN", "HD", "LOW", "NKE", "SBUX", "MCD", "CMG", "YUM", "TGT", "COST",
+    "WMT", "TJX",
+    # Staples
+    "PG", "KO", "PEP", "CL", "MDLZ", "KMB",
+    # Financials
+    "JPM", "BAC", "WFC", "C", "GS", "MS", "V", "MA", "AXP", "BLK", "SPGI",
+    # Health care
+    "JNJ", "UNH", "PFE", "MRK", "ABBV", "TMO", "ABT", "LLY", "BMY", "AMGN",
+    # Industrials
+    "BA", "CAT", "GE", "HON", "UPS", "RTX", "DE", "MMM",
+    # Energy
+    "XOM", "CVX", "COP", "SLB",
+    # Sector / industry ETFs
+    "XLK", "XLY", "XLP", "XLF", "XLE", "XLV", "XLI", "XRT", "SMH",
+]
+LARGE_UNIVERSE = [
+    Symbol(t.lower(), t, t, ["ARCA", "NASDAQ", "NYSE"], yahoo=t) for t in _LARGE_TICKERS
+]
+POINT_VALUES.update({s.key: 1.0 for s in LARGE_UNIVERSE})
+
+# SPY is the market-neutrality reference (weekly-return correlation ≈ 0 target).
+SPY_REF = SPY
+
+
+# --- Bar resolution ----------------------------------------------------------
+# Daily is the right granularity for a ~1yr mean-reversion lookback. The probe
+# also tries intraday; if intraday is retained for the window we can rerun the
+# event-zoom at finer resolution.
+BAR_INTERVAL = "Day"   # "Day" | "Minute"
+BAR_PERIOD = 1
+
+
+# --- Indicator parameters ----------------------------------------------------
+@dataclass(frozen=True)
+class IndicatorParams:
+    roc_period: int = 10
+    rsi_period: int = 14
+    macd_fast: int = 12
+    macd_slow: int = 26
+    macd_signal: int = 9
+    ma_period: int = 50
+    ma_slope_period: int = 10
+    # "about a year" of trading days; adjustable per the user's request.
+    zscore_lookback: int = 252
+    vol_window: int = 20
+
+
+# --- Regime / combo parameters (rules-based; calibrated on CALIB span) -------
+@dataclass(frozen=True)
+class ModelParams:
+    # Oil/gold "risk-off" trigger: both instruments' momentum z-scores above this
+    # (computed over the calibration span) => geopolitical-stress regime.
+    regime_z_trigger: float = 1.0
+    regime_lookback: int = 60          # window for oil/gold momentum/vol
+    # Weights in the calm regime.
+    w_momentum_calm: float = 0.6
+    w_meanrev_calm: float = 0.4
+    # Weights in the risk-off regime (lean on mean-reversion: war spikes tend to
+    # over-extend then revert).
+    w_momentum_risk: float = 0.3
+    w_meanrev_risk: float = 0.7
+    # Defensive dampener: scale ES exposure down by up to this fraction at full
+    # risk-off intensity.
+    risk_off_dampen: float = 0.5
+    zscore_lookback: int = 252         # mean-reversion lookback (kept in sync)
+
+
+# --- ES cost model (mirrors the JS Backtester knobs) -------------------------
+@dataclass(frozen=True)
+class CostModel:
+    point_value: float = 50.0   # ES = $50 per index point
+    commission: float = 2.5     # $ per contract per side
+    slippage_pts: float = 0.25  # index points per fill
+    max_contracts: int = 3      # |target| of 1.0 maps to this many contracts
+    starting_cash: float = 100_000.0
+
+
+# --- Portfolio cost model ----------------------------------------------------
+# Base cost model for the basket (ETF/share defaults). Per-symbol point values
+# come from POINT_VALUES via cost_for(); futures get heavier costs/sizing.
+PORTFOLIO_BASE_COST = CostModel(
+    point_value=1.0, commission=0.0, slippage_pts=0.01,
+    max_contracts=20, starting_cash=100_000.0,
+)
+
+
+def cost_for(key: str, base: CostModel = PORTFOLIO_BASE_COST) -> CostModel:
+    """Per-symbol CostModel: set point_value from POINT_VALUES and pick
+    futures-vs-ETF commission/slippage/sizing. ETFs trade as cheap shares;
+    futures carry real per-contract commission, slippage in points, and smaller
+    max sizing (a |target|=1.0 maps to fewer contracts)."""
+    pv = POINT_VALUES.get(key, 1.0)
+    if pv >= 5.0:  # a futures contract
+        return replace(base, point_value=pv, commission=2.5,
+                       slippage_pts=0.25, max_contracts=2)
+    return replace(base, point_value=pv)  # ETF / share
+
+
+# --- Signal parameters (per-asset composite score) ---------------------------
+@dataclass(frozen=True)
+class SignalParams:
+    # Skip-recent momentum: return over `mom_lookback` bars EXCLUDING the most
+    # recent `mom_skip` bars (the classic 12-1 anti-bubble construction).
+    mom_lookback: int = 126        # ~6 months of trading days
+    mom_skip: int = 21             # skip the last ~month (don't chase the spike)
+    # Value / mean-reversion: price vs its own ~1yr mean (negative z = cheap).
+    value_lookback: int = 252
+    # Composite blend weights (momentum vs value), renormalised internally.
+    w_momentum: float = 0.7
+    w_value: float = 0.3
+    # Overextension guard: down-weight names whose |z-score| exceeds this.
+    overext_z: float = 2.0
+    # Long-term trend gate: require close > SMA(trend_lookback) to allow a long.
+    trend_lookback: int = 200
+
+
+# --- Portfolio construction parameters ---------------------------------------
+@dataclass(frozen=True)
+class PortfolioParams:
+    top_n: int = 2                 # how many names to hold each rebalance
+    weighting: str = "equal"       # "equal" | "score"
+    allow_short: bool = False      # long/flat by default
+    gross_target: float = 1.0      # sum of |target| spread across held names
+    # Throttling: cap position changes per rebalance and ignore tiny tweaks.
+    max_trades_per_week: int = 2
+    no_trade_band: float = 0.1     # skip target changes smaller than this
+
+
+# --- Walk-forward ("rebuild") parameters -------------------------------------
+@dataclass(frozen=True)
+class WalkForwardParams:
+    warmup: int = 252              # min history before the first live decision
+    trailing_window: int = 252     # bars each re-tune scores params over
+    rebalance_days: int = 5        # hold positions ~1 week between changes
+    retune_days: int = 10          # re-tune cadence (~biweekly "rebuild")
+    objective: str = "sharpe"      # trailing-window score to maximise
+    turnover_penalty: float = 0.10  # robustness: penalise high-turnover param sets
+    hysteresis: float = 0.10       # adopt new params only if they beat the
+                                   # incumbent by this (relative) → slow rebuild
+    # Coarse grid searched at each re-tune (small ⇒ fast & robust, not overfit).
+    # 18 combos keeps the walk-forward responsive enough to drive from the UI;
+    # the hysteresis already favours stability over chasing a finer grid.
+    grid_mom_lookback: Tuple[int, ...] = (63, 126, 252)
+    grid_mom_skip: Tuple[int, ...] = (0, 21)
+    grid_value_lookback: Tuple[int, ...] = (252,)
+    grid_top_n: Tuple[int, ...] = (1, 2, 3)
+
+
+# --- Pairs / statistical-arbitrage parameters --------------------------------
+@dataclass(frozen=True)
+class PairsParams:
+    # Pair SELECTION is done on calibration data only (in-sample); the spread is
+    # traded out-of-sample after calib_end.
+    calib_end: str = "2021-12-31"
+    # Correlation is only a weak SANITY floor: the whole idea is cross-sector pairs
+    # that look UNrelated on the surface (low corr) yet co-move (cointegrated), so
+    # cointegration is the real gate, not correlation.
+    min_corr: float = 0.3          # weak floor — avoid spurious/uncorrelated noise only
+    max_pvalue: float = 0.05       # Engle-Granger cointegration p-value ceiling (the real gate)
+    top_pairs: int = 6             # how many disjoint pairs to trade
+    # Spread signal (rolling, computed out-of-sample with no look-ahead).
+    z_lookback: int = 60           # rolling window for the spread z-score
+    entry_z: float = 2.0           # |z| beyond this opens the spread
+    exit_z: float = 0.5            # |z| inside this flattens the spread (reverted)
+    # Divergence stop: if |z| blows past this the spread is de-cohering (a leg
+    # re-rated / had a fundamental shock), so bail out instead of doubling down,
+    # and stay out until it comes back inside the exit band. Caps the fat tail.
+    stop_z: float = 3.5
+    dollar_per_leg: float = 10_000.0  # target $ exposure per leg (≈ dollar-neutral)
+
+
+@dataclass(frozen=True)
+class StudyConfig:
+    indicators: IndicatorParams = field(default_factory=IndicatorParams)
+    model: ModelParams = field(default_factory=ModelParams)
+    costs: CostModel = field(default_factory=CostModel)
+    signals: SignalParams = field(default_factory=SignalParams)
+    portfolio: PortfolioParams = field(default_factory=PortfolioParams)
+    walk: WalkForwardParams = field(default_factory=WalkForwardParams)
+    pairs: PairsParams = field(default_factory=PairsParams)
+
+
+DEFAULT = StudyConfig()

--- a/tools/Python/algo-py/research/data.py
+++ b/tools/Python/algo-py/research/data.py
@@ -1,0 +1,353 @@
+"""
+research/data.py
+
+Fetch + decode T4 binary chart data into pandas DataFrames, and align several
+instruments onto a common time index.
+
+This is the ONLY T4-specific layer. It reuses the conversion repo's ChartClient
+(`get_barchart_binary` → `ChartDataStreamReaderAggr` → Bar objects) decoded via
+a CollectingHandler-style sink, then maps each Bar to an OHLCV row. Everything
+downstream (indicators / model / backtest / report) operates on plain pandas and
+is agnostic to where the data came from — so a CSV/free-data fallback can plug in
+here without touching the rest.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import os
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+import pandas as pd
+
+# NOTE: t4login (the conversion API) is imported LAZILY inside make_client — it is
+# only needed for the T4 source. Thanks to `from __future__ import annotations`
+# above, the ChartClient/NDateTime/Bar/MarketDefinition names below are used only
+# in (unevaluated) type annotations, so the CSV and Yahoo paths import and run with
+# no conversion-API dependency at all. (Before this, importing research.data — and
+# therefore every research.* entrypoint — hard-failed with ModuleNotFoundError:
+# 't4login' unless the conversion repo was installed, even in CSV mode.)
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # annotation-only; never imported at runtime
+    from t4login.client.chart_client import ChartClient
+    from t4login.datetime_.n_date_time import NDateTime
+    from t4login.definitions.chartdata.chart_format_aggr import Bar, MarketDefinition
+
+from . import config
+
+
+# --- token / client ----------------------------------------------------------
+def get_token() -> str:
+    """Bearer token for the chart API, from the T4_API_TOKEN env var.
+
+    The conversion repo has no login flow (Phase-1, chart-only); the token must
+    be supplied. Capture it from an authenticated T4 session (e.g. the running
+    JSDemo login) and export it: `export T4_API_TOKEN=...`.
+    """
+    token = os.environ.get("T4_API_TOKEN")
+    if not token:
+        raise RuntimeError(
+            "No T4_API_TOKEN set. Export a bearer token from an authenticated T4 "
+            "session before running (see research/README.md)."
+        )
+    return token
+
+
+def make_client(token: Optional[str] = None, *, base_url: Optional[str] = None) -> "ChartClient":
+    # Lazy import: only the T4 source constructs a client, so CSV/Yahoo runs never
+    # need the conversion API installed.
+    from t4login.client.chart_client import ChartClient
+    if base_url:
+        return ChartClient(token=token or get_token(), base_url=base_url)
+    return ChartClient(token=token or get_token())
+
+
+# --- decode helpers ----------------------------------------------------------
+def ndt_to_datetime(ndt: NDateTime) -> _dt.datetime:
+    """NDateTime (.NET ticks) → naive python datetime via its date/time parts."""
+    return _dt.datetime(ndt.year, ndt.month, ndt.day, ndt.hour, ndt.minute, ndt.second)
+
+
+@dataclass
+class _BarSink:
+    """Minimal ChartDataHandler: keep bars + market defs, ignore the rest."""
+    bars: List[Bar] = field(default_factory=list)
+    market_definitions: List[MarketDefinition] = field(default_factory=list)
+
+    def on_market_definition(self, md: MarketDefinition) -> None:
+        self.market_definitions.append(md)
+
+    def on_bar(self, bar: Bar) -> None:
+        self.bars.append(bar)
+
+    # Unused callbacks — must exist to satisfy the handler protocol.
+    def on_mode_change(self, *a) -> None: ...
+    def on_settlement(self, *a) -> None: ...
+    def on_open_interest(self, *a) -> None: ...
+
+
+def _bars_to_frame(bars: List[Bar], interval: str) -> pd.DataFrame:
+    """Map decoded Bars → an OHLCV DataFrame indexed by timestamp (UTC-naive).
+
+    Daily bars are indexed by their trade date; intraday by bar Time.
+    """
+    rows = []
+    for b in bars:
+        if interval == "Day":
+            ts = _dt.datetime(b.TradeDate.year, b.TradeDate.month, b.TradeDate.day)
+        else:
+            ts = ndt_to_datetime(b.Time)
+        rows.append({
+            "ts": ts,
+            "open": float(b.OpenPrice.value),
+            "high": float(b.HighPrice.value),
+            "low": float(b.LowPrice.value),
+            "close": float(b.ClosePrice.value),
+            "volume": int(b.Volume),
+        })
+    if not rows:
+        return pd.DataFrame(columns=["open", "high", "low", "close", "volume"])
+    df = pd.DataFrame(rows).set_index("ts").sort_index()
+    df = df[~df.index.duplicated(keep="last")]
+    return df
+
+
+# --- fetch -------------------------------------------------------------------
+def fetch_symbol(
+    client: ChartClient,
+    symbol: config.Symbol,
+    *,
+    start: str,
+    end: str,
+    interval: str = config.BAR_INTERVAL,
+    period: int = config.BAR_PERIOD,
+) -> pd.DataFrame:
+    """Fetch one instrument's OHLCV over [start, end].
+
+    Tries each candidate exchange id until one returns bars. Raises if none do
+    (so callers/probe can report the dead symbol clearly).
+    """
+    last_err: Optional[Exception] = None
+    for exchange_id in symbol.exchange_candidates:
+        sink = _BarSink()
+        try:
+            client.get_barchart_binary(
+                exchange_id=exchange_id,
+                contract_id=symbol.contract_id,
+                chart_type="Bar",
+                bar_interval=interval,
+                bar_period=period,
+                trade_date_start=start,
+                trade_date_end=end,
+                continuation_type=symbol.continuation_type,
+                handler=sink,
+            )
+        except Exception as e:  # network / decode / HTTP error → try next exchange
+            last_err = e
+            continue
+        df = _bars_to_frame(sink.bars, interval)
+        if not df.empty:
+            df.attrs["exchange_id"] = exchange_id
+            df.attrs["symbol"] = symbol.key
+            return df
+    if last_err:
+        raise RuntimeError(f"{symbol.key}: all exchange candidates failed; last error: {last_err}")
+    raise RuntimeError(f"{symbol.key}: no bars returned for any exchange candidate over {start}..{end}")
+
+
+def fetch_all(
+    client: ChartClient,
+    symbols: Optional[List[config.Symbol]] = None,
+    *,
+    start: str = config.FETCH_START,
+    end: str = config.FETCH_END,
+    interval: str = config.BAR_INTERVAL,
+    period: int = config.BAR_PERIOD,
+) -> dict[str, pd.DataFrame]:
+    symbols = symbols or config.SYMBOLS
+    out: dict[str, pd.DataFrame] = {}
+    for s in symbols:
+        out[s.key] = fetch_symbol(client, s, start=start, end=end, interval=interval, period=period)
+    return out
+
+
+# --- CSV source (fallback) ---------------------------------------------------
+# Column-name aliases so we accept Yahoo Finance exports and generic OHLCV files
+# without the user reformatting anything.
+_CSV_DATE_KEYS = ("date", "datetime", "time", "timestamp")
+_CSV_FIELD_ALIASES = {
+    "open": ("open", "o"),
+    "high": ("high", "h"),
+    "low": ("low", "l"),
+    "close": ("close", "adj close", "adj_close", "adjclose", "c", "last", "price"),
+    "volume": ("volume", "vol", "v"),
+}
+
+
+def load_csv_symbol(path: str) -> pd.DataFrame:
+    """Load one OHLCV series from a CSV into the same frame shape as fetch_symbol.
+
+    Headers are matched case-insensitively. A date/datetime column is required;
+    open/high/low/close are required; volume is optional (defaults to 0). If
+    only a close is present (e.g. a price-only series), OHL fall back to close.
+    """
+    raw = pd.read_csv(path)
+    if raw.empty:
+        raise RuntimeError(f"{path}: empty CSV")
+    lower = {c.lower().strip(): c for c in raw.columns}
+
+    date_col = next((lower[k] for k in _CSV_DATE_KEYS if k in lower), None)
+    if date_col is None:
+        raise RuntimeError(f"{path}: no date column (looked for {_CSV_DATE_KEYS}); columns={list(raw.columns)}")
+
+    def pick(field: str) -> Optional[str]:
+        for alias in _CSV_FIELD_ALIASES[field]:
+            if alias in lower:
+                return lower[alias]
+        return None
+
+    close_col = pick("close")
+    if close_col is None:
+        raise RuntimeError(f"{path}: no close/price column; columns={list(raw.columns)}")
+
+    out = pd.DataFrame(index=pd.to_datetime(raw[date_col], errors="coerce"))
+    out.index.name = "ts"
+    for field in ("open", "high", "low"):
+        col = pick(field)
+        out[field] = pd.to_numeric(raw[col], errors="coerce").values if col else None
+    out["close"] = pd.to_numeric(raw[close_col], errors="coerce").values
+    vol_col = pick("volume")
+    out["volume"] = (pd.to_numeric(raw[vol_col], errors="coerce").fillna(0).astype("int64").values
+                     if vol_col else 0)
+    # Fill any missing OHL from close (price-only series stay usable).
+    for field in ("open", "high", "low"):
+        out[field] = out[field].fillna(out["close"])
+
+    out = out.dropna(subset=["close"]).sort_index()
+    out = out[~out.index.duplicated(keep="last")]
+    out.attrs["source"] = "csv"
+    return out[["open", "high", "low", "close", "volume"]]
+
+
+def load_csv_all(csv_dir: str, symbols: Optional[List[config.Symbol]] = None) -> dict[str, pd.DataFrame]:
+    """Load {key}.csv for each symbol from csv_dir (key = es/cl/gc)."""
+    symbols = symbols or config.SYMBOLS
+    out: dict[str, pd.DataFrame] = {}
+    missing = []
+    for s in symbols:
+        path = os.path.join(csv_dir, f"{s.key}.csv")
+        if not os.path.exists(path):
+            missing.append(path)
+            continue
+        df = load_csv_symbol(path)
+        df.attrs["symbol"] = s.key
+        df.attrs["exchange_id"] = "csv"
+        out[s.key] = df
+    if missing:
+        raise RuntimeError(
+            f"Missing CSV(s): {missing}. Expected one file per instrument named "
+            f"es.csv / cl.csv / gc.csv in {csv_dir}."
+        )
+    return out
+
+
+# --- Yahoo Finance source (free, real data) ----------------------------------
+# yfinance is an optional dep (only this path needs it). Each symbol maps to a
+# Yahoo ticker via Symbol.yahoo_ticker (ETFs -> plain symbol, futures -> "=F"
+# continuous front-month). Returns the SAME OHLCV frame shape as the T4/CSV
+# loaders, so everything downstream is unchanged.
+def _yahoo_to_frame(raw: "pd.DataFrame") -> pd.DataFrame:
+    """Normalise a single-ticker yfinance frame to open/high/low/close/volume."""
+    df = raw.copy()
+    # yfinance returns a MultiIndex (Price, Ticker) even for one ticker; flatten
+    # to the Price level (Open/High/Low/Close/Volume).
+    if isinstance(df.columns, pd.MultiIndex):
+        df.columns = df.columns.get_level_values(0)
+    df = df.rename(columns=str.lower)
+    keep = ["open", "high", "low", "close", "volume"]
+    missing = [c for c in keep if c not in df.columns]
+    if missing:
+        raise RuntimeError(f"yahoo frame missing columns {missing}; got {list(df.columns)}")
+    out = df[keep].copy()
+    out.index = pd.to_datetime(out.index).tz_localize(None)
+    out.index.name = "ts"
+    for c in ("open", "high", "low", "close"):
+        out[c] = pd.to_numeric(out[c], errors="coerce")
+    out["volume"] = pd.to_numeric(out["volume"], errors="coerce").fillna(0).astype("int64")
+    out = out.dropna(subset=["close"]).sort_index()
+    out = out[~out.index.duplicated(keep="last")]
+    return out
+
+
+def fetch_yahoo_symbol(
+    symbol: config.Symbol,
+    *,
+    start: str = config.FETCH_START,
+    end: str = config.FETCH_END,
+) -> pd.DataFrame:
+    """Download one instrument's daily OHLCV from Yahoo Finance."""
+    try:
+        import yfinance as yf
+    except ImportError as e:  # pragma: no cover - clear actionable message
+        raise RuntimeError("yfinance not installed. Run: pip install yfinance") from e
+
+    ticker = symbol.yahoo_ticker
+    # end is exclusive in yfinance; bump by a day so the configured end is included.
+    end_excl = (pd.to_datetime(end) + pd.Timedelta(days=1)).strftime("%Y-%m-%d")
+    raw = yf.download(ticker, start=start, end=end_excl, interval="1d",
+                      auto_adjust=True, progress=False)
+    if raw is None or raw.empty:
+        raise RuntimeError(f"{symbol.key}: Yahoo returned no data for ticker {ticker!r} over {start}..{end}")
+    df = _yahoo_to_frame(raw)
+    if df.empty:
+        raise RuntimeError(f"{symbol.key}: Yahoo data for {ticker!r} empty after cleaning")
+    df.attrs["symbol"] = symbol.key
+    df.attrs["exchange_id"] = f"yahoo:{ticker}"
+    df.attrs["source"] = "yahoo"
+    return df
+
+
+def fetch_yahoo_all(
+    symbols: Optional[List[config.Symbol]] = None,
+    *,
+    start: str = config.FETCH_START,
+    end: str = config.FETCH_END,
+) -> dict[str, pd.DataFrame]:
+    symbols = symbols or config.SYMBOLS
+    out: dict[str, pd.DataFrame] = {}
+    for s in symbols:
+        out[s.key] = fetch_yahoo_symbol(s, start=start, end=end)
+    return out
+
+
+def save_frames_csv(frames: dict[str, pd.DataFrame], csv_dir: str) -> None:
+    """Write each frame to {csv_dir}/{key}.csv in a format load_csv_symbol reads
+    back (Date + OHLCV). Lets a Yahoo pull be cached for offline/reproducible
+    reruns and reused by the JSDemo UI bridge (which runs the CSV path)."""
+    os.makedirs(csv_dir, exist_ok=True)
+    for key, df in frames.items():
+        path = os.path.join(csv_dir, f"{key}.csv")
+        out = df[["open", "high", "low", "close", "volume"]].copy()
+        out.index.name = "Date"
+        out.columns = ["Open", "High", "Low", "Close", "Volume"]
+        out.to_csv(path)
+
+
+# --- align -------------------------------------------------------------------
+def align(frames: dict[str, pd.DataFrame]) -> pd.DataFrame:
+    """Outer-join per-symbol OHLCV onto a common index, column-prefixed by key.
+
+    Forward-fills gaps (different sessions/holidays) so every row has all three
+    instruments' last-known values. Returns one wide DataFrame:
+        es_open, es_high, ..., es_volume, cl_close, ..., gc_close, ...
+    """
+    wide: Optional[pd.DataFrame] = None
+    for key, df in frames.items():
+        renamed = df.add_prefix(f"{key}_")
+        wide = renamed if wide is None else wide.join(renamed, how="outer")
+    if wide is None:
+        return pd.DataFrame()
+    wide = wide.sort_index().ffill().dropna()
+    return wide

--- a/tools/Python/algo-py/research/data_csv/README.md
+++ b/tools/Python/algo-py/research/data_csv/README.md
@@ -1,0 +1,48 @@
+# Drop your data here
+
+Put one CSV per instrument in this folder:
+
+| File | Instrument |
+|------|------------|
+| `es.csv` | E-mini S&P 500 (ES) |
+| `cl.csv` | Crude oil / WTI (CL) |
+| `gc.csv` | Gold (GC) |
+
+Then run from `algo-py/`:
+
+```bash
+python -m research.run_study           # --source csv is the default
+```
+
+## Format
+
+Headers are matched **case-insensitively**, so both a Yahoo Finance export and a
+generic OHLCV file work without editing:
+
+```
+Date,Open,High,Low,Close,Adj Close,Volume      <- Yahoo style
+2024-06-03,5283.5,5290.0,5275.25,5288.75,5288.75,1250000
+...
+```
+
+```
+date,open,high,low,close,volume                <- generic
+2024-06-03,5283.5,5290.0,5275.25,5288.75,1250000
+...
+```
+
+Rules the loader applies (`research/data.py:load_csv_symbol`):
+- A date column is **required** — any of `date / datetime / time / timestamp`.
+- A close is **required** — any of `close / adj close / last / price / c`.
+- `open / high / low` are optional; if missing they fall back to `close`
+  (a close-only series still runs).
+- `volume` is optional (defaults to 0).
+- Daily bars expected; the study slices the calibration year and the war window
+  by date from whatever range the files contain.
+
+To cover the full study, each file should span roughly **2024-06-01 → 2025-06-30**
+(≈1 year of calibration + the June-2025 war window). Less is fine — the report
+just narrows to what overlaps across all three instruments.
+
+> These CSVs are gitignored (see `algo-py/.gitignore`) — they're your data, not
+> committed to the repo.

--- a/tools/Python/algo-py/research/indicators.py
+++ b/tools/Python/algo-py/research/indicators.py
@@ -1,0 +1,79 @@
+"""
+research/indicators.py
+
+Pure indicator functions over a pandas close-price Series. No state, no I/O —
+each returns a Series aligned to the input index. Momentum (ROC, RSI, MACD,
+MA-slope) and mean-reversion (rolling z-score) live here so the model layer just
+composes them.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+
+def roc(close: pd.Series, period: int) -> pd.Series:
+    """Rate of change (fractional) over `period` bars."""
+    return close.pct_change(period)
+
+
+def rsi(close: pd.Series, period: int = 14) -> pd.Series:
+    """Wilder's RSI in [0, 100]."""
+    delta = close.diff()
+    gain = delta.clip(lower=0.0)
+    loss = -delta.clip(upper=0.0)
+    # Wilder smoothing == EMA with alpha = 1/period.
+    avg_gain = gain.ewm(alpha=1.0 / period, adjust=False, min_periods=period).mean()
+    avg_loss = loss.ewm(alpha=1.0 / period, adjust=False, min_periods=period).mean()
+    rs = avg_gain / avg_loss.replace(0.0, np.nan)
+    out = 100.0 - (100.0 / (1.0 + rs))
+    # When avg_loss == 0 (pure uptrend) RSI is 100.
+    out = out.where(avg_loss != 0.0, 100.0)
+    return out
+
+
+def macd(
+    close: pd.Series, fast: int = 12, slow: int = 26, signal: int = 9
+) -> tuple[pd.Series, pd.Series, pd.Series]:
+    """Return (macd_line, signal_line, histogram)."""
+    ema_fast = close.ewm(span=fast, adjust=False).mean()
+    ema_slow = close.ewm(span=slow, adjust=False).mean()
+    macd_line = ema_fast - ema_slow
+    signal_line = macd_line.ewm(span=signal, adjust=False).mean()
+    hist = macd_line - signal_line
+    return macd_line, signal_line, hist
+
+
+def sma(close: pd.Series, period: int) -> pd.Series:
+    return close.rolling(period, min_periods=period).mean()
+
+
+def ma_slope(close: pd.Series, period: int, slope_period: int = 10) -> pd.Series:
+    """Normalised slope of an SMA: change in the MA over `slope_period`, divided
+    by the MA level (so it's comparable across price scales)."""
+    m = sma(close, period)
+    return (m - m.shift(slope_period)) / m.shift(slope_period)
+
+
+def zscore(close: pd.Series, lookback: int) -> pd.Series:
+    """Rolling z-score of price vs its trailing mean/std (the mean-reversion
+    primitive). lookback ≈ one trading year by default."""
+    mean = close.rolling(lookback, min_periods=lookback).mean()
+    std = close.rolling(lookback, min_periods=lookback).std(ddof=0)
+    return (close - mean) / std.replace(0.0, np.nan)
+
+
+def realized_vol(close: pd.Series, window: int = 20) -> pd.Series:
+    """Rolling std of log returns (per-bar; not annualised)."""
+    rets = np.log(close / close.shift(1))
+    return rets.rolling(window, min_periods=window).std(ddof=0)
+
+
+def momentum_zscore(close: pd.Series, lookback: int) -> pd.Series:
+    """Z-score of momentum (ROC over `lookback`) vs its own recent distribution —
+    used to gauge how *unusual* an instrument's move is (drives regime logic)."""
+    mom = close.pct_change(lookback)
+    mean = mom.rolling(lookback, min_periods=lookback).mean()
+    std = mom.rolling(lookback, min_periods=lookback).std(ddof=0)
+    return (mom - mean) / std.replace(0.0, np.nan)

--- a/tools/Python/algo-py/research/model.py
+++ b/tools/Python/algo-py/research/model.py
@@ -1,0 +1,128 @@
+"""
+research/model.py
+
+The rules-based combo model. It turns the aligned ES/CL/GC frame into an ES
+target position in [-1, +1] (fraction of max size), combining:
+
+  * a MOMENTUM score (trend-following on ES), and
+  * a MEAN-REVERSION score (fade ES extremes vs a ~1yr z-score),
+
+with weights and a defensive dampener CONDITIONED on an oil/gold regime. The
+regime is the "non-linear combo": oil and gold both spiking together (the war
+signature) flips the blend toward mean-reversion and trims gross ES exposure.
+
+Nothing here is fitted to the event window. Thresholds are intended to be
+calibrated on the prior-year span (see `calibrate`) — and even that is just
+standardising the regime trigger, not optimising returns.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+import pandas as pd
+
+from . import config, indicators as ind
+
+
+@dataclass
+class ModelOutput:
+    frame: pd.DataFrame   # all intermediate series (mom, mr, regime, weights, target)
+
+    @property
+    def target(self) -> pd.Series:
+        return self.frame["target"]
+
+
+def _tanh_clip(x: pd.Series, scale: float) -> pd.Series:
+    """Map an unbounded score to [-1, 1] smoothly."""
+    return np.tanh(x / scale)
+
+
+def momentum_score(close: pd.Series, p: config.IndicatorParams) -> pd.Series:
+    """Composite ES trend score in [-1, 1]: average of ROC sign-strength, MACD
+    histogram sign, and price-vs-MA — each mapped to [-1, 1]."""
+    roc = ind.roc(close, p.roc_period)
+    _, _, hist = ind.macd(close, p.macd_fast, p.macd_slow, p.macd_signal)
+    ma = ind.sma(close, p.ma_period)
+
+    roc_score = _tanh_clip(roc, scale=0.02)              # ~2% ROC ≈ ±0.76
+    hist_score = np.sign(hist).fillna(0.0)               # MACD above/below signal
+    ma_score = _tanh_clip((close - ma) / ma, scale=0.02)  # distance from MA
+
+    score = (roc_score + hist_score + ma_score) / 3.0
+    return score.clip(-1.0, 1.0)
+
+
+def mean_reversion_score(close: pd.Series, lookback: int) -> pd.Series:
+    """Fade extremes: positive (buy) when price is BELOW its ~1yr mean, negative
+    (sell) when ABOVE. In [-1, 1]."""
+    z = ind.zscore(close, lookback)
+    return (-_tanh_clip(z, scale=1.5)).clip(-1.0, 1.0)
+
+
+def oilgold_riskoff(cl_close: pd.Series, gc_close: pd.Series, m: config.ModelParams) -> pd.Series:
+    """Risk-off intensity in [0, 1] from joint oil+gold momentum.
+
+    Both oil and gold rallying hard together is the classic geopolitical-stress
+    tell. We z-score each instrument's momentum, take the MIN (so BOTH must be
+    elevated, not just one), shift by the calibrated trigger, and squash to
+    [0, 1]. 0 = calm, 1 = full risk-off.
+    """
+    cl_mz = ind.momentum_zscore(cl_close, m.regime_lookback)
+    gc_mz = ind.momentum_zscore(gc_close, m.regime_lookback)
+    joint = pd.concat([cl_mz, gc_mz], axis=1).min(axis=1)  # both must be high
+    intensity = _tanh_clip((joint - m.regime_z_trigger).clip(lower=0.0), scale=1.0)
+    return intensity.clip(0.0, 1.0).fillna(0.0)
+
+
+def combine(wide: pd.DataFrame, cfg: config.StudyConfig = config.DEFAULT) -> ModelOutput:
+    """Produce the ES target-position series from the aligned ES/CL/GC frame."""
+    p, m = cfg.indicators, cfg.model
+    es = wide["es_close"]
+    cl = wide["cl_close"]
+    gc = wide["gc_close"]
+
+    mom = momentum_score(es, p)
+    mr = mean_reversion_score(es, m.zscore_lookback)
+    risk = oilgold_riskoff(cl, gc, m)
+
+    # Conditional weights: linearly blend calm→risk-off weights by intensity.
+    w_mom = (1 - risk) * m.w_momentum_calm + risk * m.w_momentum_risk
+    w_mr = (1 - risk) * m.w_meanrev_calm + risk * m.w_meanrev_risk
+
+    raw = (w_mom * mom + w_mr * mr).clip(-1.0, 1.0)
+    # Defensive dampener: trim gross ES exposure as risk-off rises.
+    dampen = 1.0 - m.risk_off_dampen * risk
+    target = (raw * dampen).clip(-1.0, 1.0)
+
+    frame = pd.DataFrame({
+        "es_close": es,
+        "cl_close": cl,
+        "gc_close": gc,
+        "momentum": mom,
+        "mean_reversion": mr,
+        "risk_off": risk,
+        "w_mom": w_mom,
+        "w_mr": w_mr,
+        "raw": raw,
+        "target": target.fillna(0.0),
+    })
+    return ModelOutput(frame=frame)
+
+
+def calibrate(wide: pd.DataFrame, cfg: config.StudyConfig = config.DEFAULT) -> dict:
+    """Report (not optimise) the regime trigger's behaviour over the calibration
+    span: what fraction of days were flagged risk-off, and the joint-momentum
+    distribution. Used to sanity-check the threshold before evaluating the event.
+    """
+    m = cfg.model
+    calib = wide.loc[config.CALIB_START:config.CALIB_END]
+    risk = oilgold_riskoff(calib["cl_close"], calib["gc_close"], m)
+    return {
+        "calib_days": int(len(calib)),
+        "risk_off_days": int((risk > 0).sum()),
+        "risk_off_frac": float((risk > 0).mean()),
+        "risk_off_mean_intensity": float(risk.mean()),
+    }

--- a/tools/Python/algo-py/research/multi_backtest.py
+++ b/tools/Python/algo-py/research/multi_backtest.py
@@ -1,0 +1,195 @@
+"""
+research/multi_backtest.py
+
+Portfolio backtest of a target MATRIX (dates x instruments). Rather than write a
+second engine, this REUSES the audited single-asset `backtest.backtest()` once
+per instrument — preserving its one-bar lag, cost model, trade blotter and PnL
+reconciliation — then sums the per-instrument PnL into one portfolio curve.
+
+Each instrument gets its own cost model via `config.cost_for(key)` (point values
+differ: ETF shares = $1, ES = $50, NQ = $20, ...). The portfolio uses a single
+pool of starting cash, so we sum the per-bar PnL and add cash once (not N times).
+
+Also reports turnover and trades-per-week (to check the "≤2 trades/week" target)
+and an equal-weight buy-&-hold baseline over the same basket.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from typing import Dict, List
+
+import numpy as np
+import pandas as pd
+
+from . import backtest as bt, config
+
+
+@dataclass
+class PortfolioResult:
+    equity: pd.Series              # portfolio equity ($), single cash pool
+    pnl: pd.Series                 # portfolio per-bar PnL ($)
+    positions: pd.DataFrame        # contracts held per instrument
+    targets: pd.DataFrame          # the input target matrix
+    per_asset: Dict[str, bt.BacktestResult]
+    trades: pd.DataFrame           # concatenated closed trades (with `symbol`)
+    stats: dict
+    baseline_equity: pd.Series     # equal-weight buy & hold over the basket
+
+
+def _weeks(index: pd.DatetimeIndex) -> float:
+    if len(index) < 2:
+        return 1.0
+    days = (index[-1] - index[0]).days
+    return max(1.0, days / 7.0)
+
+
+def _portfolio_stats(pnl: pd.Series, equity: pd.Series, positions: pd.DataFrame,
+                     targets: pd.DataFrame, closed: pd.DataFrame,
+                     starting_cash: float, index: pd.DatetimeIndex) -> dict:
+    total = float(pnl.sum())
+    rets = pnl / starting_cash
+    ann = bt._annualization(index)
+    sharpe = float(np.sqrt(ann) * rets.mean() / rets.std(ddof=0)) if rets.std(ddof=0) > 0 else 0.0
+    running_max = equity.cummax()
+    max_dd = float((equity - running_max).min())
+
+    wins = closed[closed["realized_pnl"] > 0]["realized_pnl"] if len(closed) else pd.Series(dtype=float)
+    losses = closed[closed["realized_pnl"] < 0]["realized_pnl"] if len(closed) else pd.Series(dtype=float)
+    hit = float(len(wins) / len(closed)) if len(closed) else 0.0
+    pf = float(wins.sum() / -losses.sum()) if losses.sum() != 0 else float("inf")
+
+    # Trades = integer position changes summed across instruments.
+    pos_changes = int((positions.diff().fillna(positions) != 0).sum().sum())
+    in_market = (positions != 0).any(axis=1)
+    turn = targets.diff().abs().sum(axis=1)
+    return {
+        "net_pnl": total,
+        "return_pct": float(total / starting_cash * 100.0),
+        "sharpe": sharpe,
+        "max_drawdown": max_dd,
+        "max_drawdown_pct": float(max_dd / starting_cash * 100.0),
+        "n_bars": int(len(pnl)),
+        "n_trades": pos_changes,
+        "trades_per_week": float(pos_changes / _weeks(index)),
+        "hit_rate": hit,
+        "profit_factor": pf,
+        "avg_turnover": float(turn[turn > 0].mean()) if (turn > 0).any() else 0.0,
+        "time_in_market_pct": float(in_market.mean() * 100.0),
+    }
+
+
+def weekly_consistency(pnl: pd.Series, starting_cash: float) -> dict:
+    """Weekly-cadence consistency lens on a per-bar PnL series.
+
+    Resamples PnL to calendar weeks and reports how OFTEN it wins and how the
+    win weeks compare to the loss weeks — the metrics that matter for a
+    "profit most weeks" goal (as opposed to total return / Sharpe). All percent
+    figures are vs starting cash so they're comparable across sizing.
+    """
+    if pnl is None or len(pnl) == 0:
+        return {}
+    wk = pnl.resample("W").sum().dropna()
+    if len(wk) == 0:
+        return {}
+    wk_pct = wk / starting_cash * 100.0
+    # "Active" weeks = where it actually had exposure. Flat (≈0) weeks are warmup
+    # or out-of-market periods; counting them as losses understates the win rate
+    # and invents fake losing streaks, so judge consistency on active weeks only.
+    eps = 1e-6
+    active = wk_pct[wk_pct.abs() > eps]
+    wins = active[active > 0]
+    losses = active[active < 0]
+
+    # Longest run of consecutive strictly-negative weeks (flat weeks break it).
+    streak = worst_streak = 0
+    for v in wk_pct:
+        if v < -eps:
+            streak += 1
+            worst_streak = max(worst_streak, streak)
+        else:
+            streak = 0
+
+    avg_win = float(wins.mean()) if len(wins) else 0.0
+    avg_loss = float(losses.mean()) if len(losses) else 0.0
+    return {
+        "n_weeks": int(len(wk)),
+        "n_active_weeks": int(len(active)),
+        "pct_winning_weeks": float((active > 0).mean() * 100.0) if len(active) else 0.0,
+        "avg_week_pct": float(active.mean()) if len(active) else 0.0,
+        "median_week_pct": float(active.median()) if len(active) else 0.0,
+        "avg_win_week_pct": avg_win,
+        "avg_loss_week_pct": avg_loss,
+        "win_loss_ratio": float(avg_win / -avg_loss) if avg_loss < 0 else float("inf"),
+        "best_week_pct": float(wk_pct.max()),
+        "worst_week_pct": float(wk_pct.min()),
+        "max_losing_streak_weeks": int(worst_streak),
+        "weekly_sharpe": (float(np.sqrt(52) * wk_pct.mean() / wk_pct.std(ddof=0))
+                          if wk_pct.std(ddof=0) > 0 else 0.0),
+    }
+
+
+def _cost_for_key(k: str, costs_by_key: Dict[str, config.CostModel] | None) -> config.CostModel:
+    """Per-instrument cost model: an explicit override (e.g. dollar-neutral pairs
+    sizing) if supplied, else the default from config.cost_for."""
+    if costs_by_key is not None and k in costs_by_key:
+        return costs_by_key[k]
+    return config.cost_for(k)
+
+
+def backtest_portfolio(targets: pd.DataFrame, closes: Dict[str, pd.Series],
+                       cfg: config.StudyConfig = config.DEFAULT,
+                       costs_by_key: Dict[str, config.CostModel] | None = None) -> PortfolioResult:
+    keys: List[str] = list(targets.columns)
+    starting_cash = cfg.costs.starting_cash
+
+    per: Dict[str, bt.BacktestResult] = {}
+    pnl_sum: pd.Series | None = None
+    positions: Dict[str, pd.Series] = {}
+    closed_frames: List[pd.DataFrame] = []
+
+    for k in keys:
+        ccfg = replace(cfg, costs=_cost_for_key(k, costs_by_key))
+        res = bt.backtest(closes[k], targets[k], ccfg)
+        per[k] = res
+        positions[k] = res.positions
+        pnl_sum = res.pnl if pnl_sum is None else pnl_sum.add(res.pnl, fill_value=0.0)
+        if len(res.trades):
+            ct = res.trades[res.trades["realized_pnl"].notna()].copy()
+            if len(ct):
+                ct["symbol"] = k
+                closed_frames.append(ct)
+
+    index = pnl_sum.index
+    equity = starting_cash + pnl_sum.cumsum()
+    positions_df = pd.DataFrame(positions)
+    closed = pd.concat(closed_frames) if closed_frames else pd.DataFrame(columns=["realized_pnl", "symbol"])
+    stats = _portfolio_stats(pnl_sum, equity, positions_df, targets, closed, starting_cash, index)
+
+    baseline_equity = _equal_weight_baseline(closes, targets, cfg, starting_cash, costs_by_key)
+    return PortfolioResult(
+        equity=equity, pnl=pnl_sum, positions=positions_df, targets=targets,
+        per_asset=per, trades=closed, stats=stats, baseline_equity=baseline_equity,
+    )
+
+
+def _equal_weight_baseline(closes: Dict[str, pd.Series], targets: pd.DataFrame,
+                           cfg: config.StudyConfig, starting_cash: float,
+                           costs_by_key: Dict[str, config.CostModel] | None = None) -> pd.Series:
+    """Hold an equal gross-weight in every basket member, continuously, from the
+    first bar the strategy could trade — the naive 'just own the basket' line."""
+    keys = list(targets.columns)
+    n = len(keys)
+    # Start when the strategy first takes any position (fair comparison window).
+    active = targets.abs().sum(axis=1) > 0
+    start_ts = active.idxmax() if active.any() else targets.index[0]
+    level = cfg.portfolio.gross_target / max(1, n)
+
+    pnl_sum: pd.Series | None = None
+    for k in keys:
+        bt_target = pd.Series(0.0, index=targets.index)
+        bt_target.loc[start_ts:] = level
+        ccfg = replace(cfg, costs=_cost_for_key(k, costs_by_key))
+        res = bt.backtest(closes[k], bt_target, ccfg)
+        pnl_sum = res.pnl if pnl_sum is None else pnl_sum.add(res.pnl, fill_value=0.0)
+    return starting_cash + pnl_sum.cumsum()

--- a/tools/Python/algo-py/research/pairs.py
+++ b/tools/Python/algo-py/research/pairs.py
@@ -1,0 +1,190 @@
+"""
+research/pairs.py
+
+Market-neutral cross-sector pairs trading (statistical arbitrage).
+
+Pick instruments that LOOK unrelated (fast food / tech / commerce) but co-move
+under macro shifts, then trade the SPREAD market-neutrally: long the laggard leg,
+short the leader leg, and bet the spread reverts to its mean. Because the two
+legs hedge each other, weekly P&L stops being "did the market go up" and becomes
+"did the spread revert" — the textbook route to a high weekly WIN RATE without
+riding equity beta.
+
+Discipline (mirrors the rest of research/): pair SELECTION and the hedge ratio
+are fit on the calibration window only; the spread is then traded OUT-OF-SAMPLE.
+The rolling z-score uses only trailing data and is acted on with the backtester's
+one-bar lag, so there is no look-ahead.
+
+Reuses `indicators.zscore` for the spread z-score and `config.cost_for` for the
+per-leg cost model (only max_contracts is overridden, for dollar-neutral sizing).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import itertools
+from dataclasses import dataclass
+from typing import Dict, List, Tuple
+
+import numpy as np
+import pandas as pd
+
+from . import config, indicators
+
+
+@dataclass
+class Pair:
+    a: str            # leg A key
+    b: str            # leg B key
+    beta: float       # hedge ratio: spread = log(A) - beta * log(B)
+    pvalue: float     # Engle-Granger cointegration p-value (in-sample)
+    corr: float       # daily log-return correlation (in-sample)
+
+    @property
+    def label(self) -> str:
+        return f"{self.a}-{self.b}"
+
+
+# --- selection ---------------------------------------------------------------
+def select_pairs(closes: Dict[str, pd.Series], params: config.PairsParams) -> List[Pair]:
+    """Find tradeable pairs on the CALIBRATION window only.
+
+    A pair qualifies when (1) the two legs' daily log returns are correlated
+    above `min_corr` AND (2) their log-price spread is cointegrated (Engle-Granger
+    p-value <= `max_pvalue`) — correlation alone can pick pairs whose spread drifts
+    forever and never reverts. Qualifying pairs are ranked by p-value (most
+    stationary first) and chosen GREEDILY so the selected set is DISJOINT (no
+    instrument used twice) — each pair is then an independent dollar-neutral book.
+    """
+    from statsmodels.tsa.stattools import coint  # local import: optional dep
+
+    keys = list(closes.keys())
+    calib: Dict[str, pd.Series] = {
+        k: closes[k].loc[:params.calib_end].dropna() for k in keys
+    }
+    rets = pd.DataFrame({k: np.log(calib[k]).diff() for k in keys}).dropna()
+
+    candidates: List[Pair] = []
+    for a, b in itertools.combinations(keys, 2):
+        ca, cb = calib[a].align(calib[b], join="inner")
+        if len(ca) < 120:                      # need ~6mo of overlap to trust the test
+            continue
+        if a not in rets or b not in rets:
+            continue
+        corr = float(rets[a].corr(rets[b]))
+        if not np.isfinite(corr) or corr < params.min_corr:
+            continue
+        la, lb = np.log(ca.values), np.log(cb.values)
+        try:
+            _tstat, pval, _crit = coint(la, lb)
+        except Exception:
+            continue
+        if not np.isfinite(pval) or pval > params.max_pvalue:
+            continue
+        beta = float(np.polyfit(lb, la, 1)[0])  # OLS hedge ratio (log-log)
+        candidates.append(Pair(a, b, beta, float(pval), corr))
+
+    candidates.sort(key=lambda p: p.pvalue)     # most stationary first
+    chosen: List[Pair] = []
+    used: set[str] = set()
+    for p in candidates:
+        if p.a in used or p.b in used:
+            continue
+        chosen.append(p)
+        used.update((p.a, p.b))
+        if len(chosen) >= params.top_pairs:
+            break
+    return chosen
+
+
+# --- signal ------------------------------------------------------------------
+def spread_zscore(a: pd.Series, b: pd.Series, beta: float, lookback: int) -> pd.Series:
+    """Rolling z-score of the log-price spread (the mean-reversion signal)."""
+    spread = np.log(a) - beta * np.log(b)
+    return indicators.zscore(spread, lookback)
+
+
+def _state_from_z(z: pd.Series, entry: float, exit_: float, stop: float) -> pd.Series:
+    """Spread position for leg A from its z-score, with entry/exit hysteresis and a
+    divergence stop.
+
+    +1 = long the spread (long A / short B), opened when z < -entry (A cheap).
+    -1 = short the spread (short A / long B), opened when z > +entry (A rich).
+     0 = flat, restored when |z| < exit (reverted). Positions persist between entry
+    and exit (hysteresis) so it doesn't flicker around the band. NaN (warmup) = flat.
+
+    Divergence stop: while holding, if |z| >= `stop` the spread is blowing out (a leg
+    re-rated / shocked) — exit and LOCK OUT new entries until |z| comes back inside
+    the exit band, so we don't keep re-entering an un-reverting spread. New positions
+    are only opened when entry < |z| < stop (never initiate into an already-blown spread).
+    """
+    out = np.zeros(len(z))
+    state = 0
+    locked = False
+    for i, v in enumerate(z.values):
+        if not np.isfinite(v):
+            state, locked = 0, False
+        elif state != 0:                       # holding
+            if abs(v) >= stop:                 # divergence stop → bail and lock out
+                state, locked = 0, True
+            elif abs(v) < exit_:               # normal mean-reversion exit
+                state = 0
+        else:                                  # flat
+            if locked:
+                if abs(v) < exit_:             # spread normalised → re-arm
+                    locked = False
+            elif entry < v < stop:
+                state = -1
+            elif -stop < v < -entry:
+                state = 1
+        out[i] = state
+    return pd.Series(out, index=z.index)
+
+
+def build_targets(
+    wide: pd.DataFrame, pairs: List[Pair], params: config.PairsParams
+) -> Tuple[pd.DataFrame, Dict[str, pd.Series]]:
+    """Per-leg signed target matrix (dates x leg-keys) in {-1, 0, +1}.
+
+    Leg A carries the spread position; leg B carries the opposite. The calibration
+    window is masked flat so reported P&L is out-of-sample. Also returns each
+    pair's z-score series (for plotting). Pairs are disjoint, so columns are unique.
+    """
+    legs: List[str] = []
+    for p in pairs:
+        legs += [p.a, p.b]
+    targets = pd.DataFrame(0.0, index=wide.index, columns=legs)
+    zscores: Dict[str, pd.Series] = {}
+
+    for p in pairs:
+        a = wide[f"{p.a}_close"]
+        b = wide[f"{p.b}_close"]
+        z = spread_zscore(a, b, p.beta, params.z_lookback)
+        state = _state_from_z(z, params.entry_z, params.exit_z, params.stop_z)
+        targets[p.a] = state
+        targets[p.b] = -state
+        zscores[p.label] = z
+
+    # Out-of-sample only: nothing is traded on or before calib_end.
+    targets.loc[:params.calib_end] = 0.0
+    return targets, zscores
+
+
+# --- sizing ------------------------------------------------------------------
+def dollar_neutral_costs(
+    wide: pd.DataFrame, pairs: List[Pair], params: config.PairsParams
+) -> Dict[str, config.CostModel]:
+    """Per-leg CostModel whose max_contracts ≈ `dollar_per_leg / ref_price`, so a
+    target of ±1 deploys roughly `dollar_per_leg` of exposure on every leg — i.e.
+    the two legs of a pair are approximately dollar-neutral. Ref price is the leg's
+    price at calib_end (in-sample, no look-ahead)."""
+    legs: set[str] = set()
+    for p in pairs:
+        legs.update((p.a, p.b))
+    out: Dict[str, config.CostModel] = {}
+    for k in legs:
+        col = wide[f"{k}_close"].loc[:params.calib_end].dropna()
+        ref = float(col.iloc[-1]) if len(col) else float(wide[f"{k}_close"].dropna().iloc[0])
+        mc = max(1, int(round(params.dollar_per_leg / ref))) if ref > 0 else 1
+        out[k] = dataclasses.replace(config.cost_for(k), max_contracts=mc)
+    return out

--- a/tools/Python/algo-py/research/portfolio.py
+++ b/tools/Python/algo-py/research/portfolio.py
@@ -1,0 +1,162 @@
+"""
+research/portfolio.py
+
+Cross-sectional construction: turn the basket's per-asset signals into a target
+matrix (dates x instruments, each target in [0, 1], or [-1, 1] with shorts).
+
+Two responsibilities, kept separate so the walk-forward can drive them with
+per-segment parameters:
+
+  * `composite_scores(closes, signal_params)` — score every name on every date,
+    comparing names AGAINST EACH OTHER (cross-sectional standardisation), with
+    the overextension + trend guards disqualifying ineligible longs.
+  * `select_targets(scores, closes, port_params, rebalance_idx)` — on each
+    rebalance date pick the top-N, weight them, hold flat in between, and apply
+    the trade THROTTLE (no-trade band + max-changes-per-rebalance) so the book
+    turns over at most a couple of times a week.
+
+`build_targets()` wires both together for a fixed-parameter run; the walk-forward
+calls the two pieces directly with the params it re-tuned for each segment.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+import numpy as np
+import pandas as pd
+
+from . import config, signals as sig
+
+
+# --- helpers -----------------------------------------------------------------
+def closes_from_wide(wide: pd.DataFrame, basket: Optional[List[config.Symbol]] = None) -> Dict[str, pd.Series]:
+    """Pull each basket member's close column out of the aligned wide frame.
+    `data.align` prefixes columns by key, e.g. spy_close."""
+    basket = basket or config.BASKET
+    out: Dict[str, pd.Series] = {}
+    for s in basket:
+        col = f"{s.key}_close"
+        if col in wide.columns:
+            out[s.key] = wide[col].astype(float)
+    if not out:
+        raise RuntimeError(
+            f"No basket close columns found in wide frame. Expected one of "
+            f"{[s.key + '_close' for s in basket]}; got {list(wide.columns)[:8]}..."
+        )
+    return out
+
+
+def _xs_zscore(wide: pd.DataFrame) -> pd.DataFrame:
+    """Cross-sectional z-score: standardise each ROW across columns (compare the
+    names against each other on that date). Rows with <2 finite names pass
+    through demeaned-only (std undefined)."""
+    mean = wide.mean(axis=1)
+    std = wide.std(axis=1, ddof=0).replace(0.0, np.nan)
+    return wide.sub(mean, axis=0).div(std, axis=0)
+
+
+# --- scoring -----------------------------------------------------------------
+def composite_scores(closes: Dict[str, pd.Series], p: config.SignalParams) -> pd.DataFrame:
+    """Eligible-long composite score per (date, instrument). NaN = not eligible
+    (disqualified by the overextension or trend guard, or still warming up).
+
+    Momentum and value are cross-sectionally standardised so they're comparable,
+    then blended by the (renormalised) weights. A name is disqualified when it is
+    overextended to the UPSIDE (z above +overext_z — the bubble guard) or when it
+    fails the long-term trend gate.
+    """
+    keys = list(closes.keys())
+    per = {k: sig.asset_signals(closes[k], p) for k in keys}
+
+    mom = pd.DataFrame({k: per[k]["momentum"] for k in keys})
+    val = pd.DataFrame({k: per[k]["value"] for k in keys})
+    trend = pd.DataFrame({k: per[k]["trend_ok"] for k in keys}).astype(bool)
+    # value = -z, so signed price z-score is -value (positive = above mean).
+    z_price = -val
+
+    z_mom = _xs_zscore(mom)
+    z_val = _xs_zscore(val)
+    wsum = p.w_momentum + p.w_value
+    wm = p.w_momentum / wsum if wsum else 0.5
+    wv = p.w_value / wsum if wsum else 0.5
+    blended = wm * z_mom + wv * z_val
+
+    # Disqualify overextended-up names (bubble guard) and down-trending names.
+    eligible = (z_price <= p.overext_z) & trend
+    return blended.where(eligible)
+
+
+# --- selection + throttle ----------------------------------------------------
+def _desired_row(score_row: pd.Series, p: config.PortfolioParams) -> pd.Series:
+    """Top-N selection + weighting for a single rebalance date → target row."""
+    target = pd.Series(0.0, index=score_row.index)
+    eligible = score_row.dropna()
+    if eligible.empty:
+        return target
+    chosen = eligible.sort_values(ascending=False).head(p.top_n)
+    if p.weighting == "score":
+        pos = chosen.clip(lower=0.0)
+        if pos.sum() > 0:
+            w = pos / pos.sum()
+        else:  # all chosen scores <= 0 → fall back to equal
+            w = pd.Series(1.0 / len(chosen), index=chosen.index)
+    else:  # equal weight
+        w = pd.Series(1.0 / len(chosen), index=chosen.index)
+    target.loc[chosen.index] = (w * p.gross_target).values
+    return target
+
+
+def _throttle(prev: pd.Series, desired: pd.Series, p: config.PortfolioParams) -> pd.Series:
+    """Limit how much the book changes at one rebalance.
+
+    1. No-trade band: ignore per-name target changes smaller than `no_trade_band`
+       (keep the previous weight for those names).
+    2. Trade cap: if more than `max_trades_per_week` names would still change,
+       keep only the largest |Δ| changes and revert the rest to `prev`.
+    """
+    delta = desired - prev
+    band = delta.where(delta.abs() >= p.no_trade_band, 0.0)
+    changed = band[band != 0.0]
+    if len(changed) > p.max_trades_per_week:
+        keep = changed.abs().sort_values(ascending=False).head(p.max_trades_per_week).index
+        band = band.where(band.index.isin(keep), 0.0)
+    return prev + band
+
+
+def select_targets(
+    scores: pd.DataFrame,
+    p: config.PortfolioParams,
+    rebalance_idx: List[pd.Timestamp],
+) -> pd.DataFrame:
+    """Walk the rebalance dates: choose desired holdings, throttle the change vs
+    the currently-held book, then hold flat until the next rebalance. Returns the
+    full target matrix (dates x instruments), forward-filled between rebalances."""
+    # Compute the held book only at rebalance dates (carrying `prev` forward),
+    # then forward-fill between them — far cheaper than touching every row.
+    cols = scores.columns
+    prev = pd.Series(0.0, index=cols)
+    sparse = pd.DataFrame(index=scores.index, columns=cols, dtype=float)
+    valid = scores.index
+    for ts in rebalance_idx:
+        if ts not in valid:
+            continue
+        desired = _desired_row(scores.loc[ts], p)
+        prev = _throttle(prev, desired, p)
+        sparse.loc[ts] = prev.values
+    return sparse.ffill().fillna(0.0)
+
+
+def rebalance_dates(index: pd.DatetimeIndex, every: int, start_at: int = 0) -> List[pd.Timestamp]:
+    """Every `every` bars starting at offset `start_at` (e.g. after warmup)."""
+    positions = range(max(0, start_at), len(index), max(1, every))
+    return [index[i] for i in positions]
+
+
+def build_targets(closes: Dict[str, pd.Series], cfg: config.StudyConfig = config.DEFAULT) -> pd.DataFrame:
+    """Fixed-parameter target matrix (no walk-forward). Score the whole span with
+    one parameter set and rebalance every `walk.rebalance_days` after warmup."""
+    scores = composite_scores(closes, cfg.signals)
+    idx = scores.index
+    rb = rebalance_dates(idx, cfg.walk.rebalance_days, start_at=cfg.walk.warmup)
+    return select_targets(scores, cfg.portfolio, rb)

--- a/tools/Python/algo-py/research/probe_data.py
+++ b/tools/Python/algo-py/research/probe_data.py
@@ -1,0 +1,111 @@
+"""
+research/probe_data.py  —  STEP 0 GATE
+
+Before building anything on T4 data, confirm the unknowns that can't be answered
+from code:
+
+  1. Auth: is the T4_API_TOKEN valid?
+  2. Symbols: which exchange_id actually returns ES / CL / GC?
+  3. Retention: does the sim feed serve the JUNE 2025 window (and the prior year)?
+  4. Resolution: is intraday (Minute) available for the window, or only Day?
+
+It prints a per-symbol coverage table and a clear GO / NO-GO verdict. Run:
+
+    export T4_API_TOKEN=...
+    python -m research.probe_data        # from algo-py/
+
+NO-GO means the sim feed lacks the window — at which point we decide on a
+fallback data source (CSV / free daily) rather than silently degrading.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Optional
+
+import pandas as pd
+
+from . import config, data
+
+
+def _probe_one(client, symbol: config.Symbol, start: str, end: str, interval: str) -> dict:
+    result = {"symbol": symbol.key, "interval": interval, "exchange": None,
+              "bars": 0, "first": None, "last": None, "error": None}
+    try:
+        df = data.fetch_symbol(client, symbol, start=start, end=end, interval=interval, period=1)
+        result["exchange"] = df.attrs.get("exchange_id")
+        result["bars"] = len(df)
+        if len(df):
+            result["first"] = df.index.min().date().isoformat()
+            result["last"] = df.index.max().date().isoformat()
+    except Exception as e:
+        result["error"] = f"{type(e).__name__}: {e}"
+    return result
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    try:
+        token = data.get_token()
+    except RuntimeError as e:
+        print(f"[probe] {e}", file=sys.stderr)
+        return 2
+
+    client = data.make_client(token)
+    rows = []
+    try:
+        for sym in config.SYMBOLS:
+            # (a) recent sanity window (~last 10 days) — proves auth+symbol work now
+            now = pd.Timestamp.now("UTC").normalize()
+            recent_start = (now - pd.Timedelta(days=10)).date().isoformat()
+            recent_end = now.date().isoformat()
+            rows.append({"phase": "recent", **_probe_one(client, sym, recent_start, recent_end, "Day")})
+            # (b) the event window itself (daily)
+            rows.append({"phase": "event-day", **_probe_one(client, sym, config.EVENT_START, config.EVENT_END, "Day")})
+            # (c) the event window intraday (optional finer zoom)
+            rows.append({"phase": "event-min", **_probe_one(client, sym, config.EVENT_START, config.EVENT_END, "Minute")})
+            # (d) the start of the calibration year (retention depth check)
+            rows.append({"phase": "calib-start", **_probe_one(client, sym, config.CALIB_START,
+                                                              (pd.Timestamp(config.CALIB_START) + pd.Timedelta(days=7)).date().isoformat(),
+                                                              "Day")})
+    finally:
+        client.close()
+
+    table = pd.DataFrame(rows)
+    print("\n=== T4 data probe ===")
+    with pd.option_context("display.max_columns", None, "display.width", 160):
+        print(table.to_string(index=False))
+
+    # GO/NO-GO: every symbol must return DAILY bars for the event window AND the
+    # calibration start. Intraday is a bonus.
+    def covered(phase: str) -> set:
+        ok = table[(table["phase"] == phase) & (table["bars"] > 0)]["symbol"]
+        return set(ok)
+
+    need = {s.key for s in config.SYMBOLS}
+    event_ok = covered("event-day")
+    calib_ok = covered("calib-start")
+    intraday_ok = covered("event-min")
+
+    print("\n--- verdict ---")
+    print(f"event window (daily) covered for : {sorted(event_ok) or 'NONE'}")
+    print(f"calibration start covered for    : {sorted(calib_ok) or 'NONE'}")
+    print(f"intraday available for           : {sorted(intraday_ok) or 'NONE'}")
+
+    if need <= event_ok and need <= calib_ok:
+        extra = " (intraday available - can run --intraday)" if need <= intraday_ok else " (daily only)"
+        print(f"\n[GO]  -- full ~1yr + event window available for ES/CL/GC{extra}")
+        return 0
+
+    missing_event = sorted(need - event_ok)
+    missing_calib = sorted(need - calib_ok)
+    print("\n[NO-GO]  -- sim feed does not fully cover the study window.")
+    if missing_event:
+        print(f"  missing event-window data for : {missing_event}")
+    if missing_calib:
+        print(f"  missing calibration-year data for : {missing_calib}")
+    print("  → choose a fallback data source (user CSVs / free daily) before proceeding.")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/Python/algo-py/research/report.py
+++ b/tools/Python/algo-py/research/report.py
@@ -1,0 +1,535 @@
+"""
+research/report.py
+
+Render the study to disk: matplotlib PNGs + a Markdown report. Uses the non-
+interactive Agg backend so it runs headless. All outputs land in an output dir
+(default research/output/).
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+import matplotlib
+matplotlib.use("Agg")  # headless; must precede pyplot import
+import matplotlib.pyplot as plt
+import matplotlib.dates as mdates
+import pandas as pd
+
+from . import config
+from .backtest import BacktestResult
+
+
+def _ensure(out_dir: str) -> None:
+    os.makedirs(out_dir, exist_ok=True)
+
+
+def plot_price_positions(model_frame: pd.DataFrame, positions: pd.Series, out_dir: str) -> str:
+    _ensure(out_dir)
+    fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(12, 7), sharex=True, height_ratios=[3, 1])
+    ax1.plot(model_frame.index, model_frame["es_close"], color="#1f77b4", lw=1.0, label="ES close")
+    ax1.set_title("ES price & model positions (calibration span)")
+    ax1.legend(loc="upper left"); ax1.grid(alpha=0.3)
+    ax2.fill_between(positions.index, positions.values, step="pre", color="#ff7f0e", alpha=0.6)
+    ax2.axhline(0, color="k", lw=0.6)
+    ax2.set_ylabel("contracts"); ax2.grid(alpha=0.3)
+    fig.autofmt_xdate()
+    path = os.path.join(out_dir, "price_positions.png")
+    fig.savefig(path, dpi=110, bbox_inches="tight"); plt.close(fig)
+    return path
+
+
+def plot_equity(result: BacktestResult, out_dir: str) -> str:
+    _ensure(out_dir)
+    fig, ax = plt.subplots(figsize=(12, 5))
+    ax.plot(result.equity.index, result.equity.values, color="#2ca02c", lw=1.3, label="Combo model")
+    ax.plot(result.buy_hold_equity.index, result.buy_hold_equity.values,
+            color="#888", lw=1.0, ls="--", label="ES buy & hold (1 lot)")
+    ax.set_title("Equity curve ($)"); ax.legend(loc="upper left"); ax.grid(alpha=0.3)
+    fig.autofmt_xdate()
+    path = os.path.join(out_dir, "equity.png")
+    fig.savefig(path, dpi=110, bbox_inches="tight"); plt.close(fig)
+    return path
+
+
+def plot_war_zoom(model_frame: pd.DataFrame, positions: pd.Series, out_dir: str) -> str:
+    """Event-window zoom: ES/CL/GC normalised to 100 at window start, with the
+    risk-off shading and ES position underneath."""
+    _ensure(out_dir)
+    pad_start = (pd.Timestamp(config.EVENT_START) - pd.Timedelta(days=20))
+    pad_end = (pd.Timestamp(config.EVENT_END) + pd.Timedelta(days=10))
+    z = model_frame.loc[pad_start:pad_end]
+    if z.empty:
+        z = model_frame
+    base = z.iloc[0]
+    fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(12, 8), sharex=True, height_ratios=[3, 1])
+    for key, color in (("es_close", "#1f77b4"), ("cl_close", "#000000"), ("gc_close", "#d4af37")):
+        ax1.plot(z.index, z[key] / base[key] * 100.0, color=color, lw=1.2, label=key.split("_")[0].upper())
+    ax1.axvspan(pd.Timestamp(config.EVENT_START), pd.Timestamp(config.EVENT_END),
+                color="red", alpha=0.08, label="war window")
+    ax1.set_title("June 2025 war window — ES / oil / gold (normalised = 100 at start)")
+    ax1.legend(loc="upper left"); ax1.grid(alpha=0.3)
+
+    ax2.fill_between(z.index, z["risk_off"], step="pre", color="red", alpha=0.3, label="risk-off intensity")
+    pos = positions.reindex(z.index).fillna(0.0)
+    ax2b = ax2.twinx()
+    ax2b.step(z.index, pos.values, where="pre", color="#ff7f0e", lw=1.2, label="ES position")
+    ax2.set_ylabel("risk-off"); ax2b.set_ylabel("contracts")
+    ax2.grid(alpha=0.3)
+    ax2.legend(loc="upper left"); ax2b.legend(loc="upper right")
+    ax1.xaxis.set_major_formatter(mdates.DateFormatter("%b %d"))
+    fig.autofmt_xdate()
+    path = os.path.join(out_dir, "war_zoom.png")
+    fig.savefig(path, dpi=110, bbox_inches="tight"); plt.close(fig)
+    return path
+
+
+def _fmt(v: float, pct: bool = False) -> str:
+    if v == float("inf"):
+        return "∞"
+    return f"{v:,.2f}{'%' if pct else ''}"
+
+
+def write_report(
+    *,
+    out_dir: str,
+    full_stats: dict,
+    event_stats: dict,
+    calib_info: dict,
+    data_summary: dict,
+    images: list[str],
+    resolution: str,
+) -> str:
+    """Write report.md tying the artifacts together with honest caveats."""
+    _ensure(out_dir)
+    img_md = "\n".join(f"![{os.path.basename(p)}]({os.path.basename(p)})" for p in images)
+
+    def stats_table(s: dict) -> str:
+        return (
+            "| metric | value |\n|---|---|\n"
+            f"| Net PnL | ${_fmt(s['net_pnl'])} |\n"
+            f"| Return | {_fmt(s['return_pct'], pct=True)} |\n"
+            f"| Sharpe (annualised) | {_fmt(s['sharpe'])} |\n"
+            f"| Max drawdown | ${_fmt(s['max_drawdown'])} ({_fmt(s['max_drawdown_pct'], pct=True)}) |\n"
+            f"| Trades | {s['n_trades']} |\n"
+            f"| Hit rate | {_fmt(s['hit_rate'] * 100, pct=True)} |\n"
+            f"| Profit factor | {_fmt(s['profit_factor'])} |\n"
+            f"| Time in market | {_fmt(s['time_in_market_pct'], pct=True)} |\n"
+        )
+
+    md = f"""# ES combo-signal study — June 2025 US–Iran war
+
+Momentum + mean-reversion on **ES**, with oil/gold **conditional weighting**,
+evaluated through the June 2025 "12-Day War" ({config.EVENT_START} → {config.EVENT_END}).
+
+## 1. Data
+- Instruments: {data_summary.get('symbols')}
+- Span fetched: {config.FETCH_START} → {config.FETCH_END}
+- Resolution: **{resolution}**
+- Bars: {data_summary.get('rows')} aligned rows
+
+## 2. Regime calibration (prior year)
+- Calibration span: {config.CALIB_START} → {config.CALIB_END} ({calib_info.get('calib_days')} days)
+- Risk-off days flagged: {calib_info.get('risk_off_days')} ({_fmt(calib_info.get('risk_off_frac', 0) * 100, pct=True)})
+- Mean risk-off intensity: {_fmt(calib_info.get('risk_off_mean_intensity', 0))}
+
+## 3. Backtest — full span (calibration + event)
+{stats_table(full_stats)}
+
+## 4. War-window performance ({config.EVENT_START} → {config.EVENT_END})
+{stats_table(event_stats)}
+
+## 5. Charts
+{img_md}
+
+## 6. Caveats (read these)
+- **Single event = case study, not validation.** A ~2-week war is one regime
+  observation. These numbers illustrate behaviour; they are **not** statistically
+  significant evidence the strategy "works".
+- **Nothing was fit on the event window.** Indicator lookbacks and the regime
+  trigger are calibrated on the prior year only; the event is held out.
+- **Rules-based, not optimised.** Weights/thresholds are hand-set defaults
+  (`config.py`), chosen for transparency, not tuned for returns.
+- **Costs are modelled, not real fills.** Slippage/commission are approximations;
+  gaps around the strikes would be worse in practice.
+- **Resolution matters.** If only daily data was available, intraday dynamics of
+  the strikes (Jun 21–22) are invisible here.
+"""
+    path = os.path.join(out_dir, "report.md")
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(md)
+    return path
+
+
+# =============================================================================
+# Portfolio rotation study (research/run_portfolio_study.py)
+# =============================================================================
+# Decoupled from multi_backtest's types on purpose — these take plain Series /
+# DataFrames so report.py keeps depending only on pandas/matplotlib.
+
+def plot_portfolio_equity(equity: pd.Series, baseline_equity: pd.Series, out_dir: str,
+                          label: str = "Rotation (walk-forward, OOS)",
+                          baseline_label: str = "Equal-weight buy & hold",
+                          title: str = "Portfolio equity ($) — out-of-sample") -> str:
+    """Out-of-sample portfolio equity vs the equal-weight buy-&-hold baseline."""
+    _ensure(out_dir)
+    fig, ax = plt.subplots(figsize=(12, 5))
+    ax.plot(equity.index, equity.values, color="#2ca02c", lw=1.4, label=label)
+    ax.plot(baseline_equity.index, baseline_equity.values, color="#888", lw=1.0, ls="--",
+            label=baseline_label)
+    ax.set_title(title); ax.legend(loc="upper left"); ax.grid(alpha=0.3)
+    fig.autofmt_xdate()
+    path = os.path.join(out_dir, "portfolio_equity.png")
+    fig.savefig(path, dpi=110, bbox_inches="tight"); plt.close(fig)
+    return path
+
+
+def plot_param_drift(params_log: pd.DataFrame, out_dir: str) -> str:
+    """Show how slowly the re-tuned parameters move — the 'rebuild' made visible.
+    Vertical marks flag re-tunes where the parameter set actually switched."""
+    _ensure(out_dir)
+    fig, axes = plt.subplots(3, 1, figsize=(12, 8), sharex=True)
+    if not params_log.empty:
+        idx = params_log.index
+        axes[0].step(idx, params_log["mom_lookback"], where="post", color="#1f77b4", label="mom_lookback")
+        axes[0].step(idx, params_log["value_lookback"], where="post", color="#9467bd", label="value_lookback")
+        axes[0].set_ylabel("bars"); axes[0].legend(loc="upper left"); axes[0].grid(alpha=0.3)
+        axes[1].step(idx, params_log["mom_skip"], where="post", color="#ff7f0e", label="mom_skip")
+        axes[1].set_ylabel("skip bars"); axes[1].legend(loc="upper left"); axes[1].grid(alpha=0.3)
+        axes[2].step(idx, params_log["top_n"], where="post", color="#2ca02c", label="top_n")
+        axes[2].set_ylabel("held names"); axes[2].legend(loc="upper left"); axes[2].grid(alpha=0.3)
+        if "switched" in params_log.columns:
+            for ts in params_log.index[params_log["switched"].astype(bool)]:
+                for ax in axes:
+                    ax.axvline(ts, color="red", alpha=0.25, lw=0.8)
+    axes[0].set_title("Re-tuned parameters over time (red = parameter set switched)")
+    fig.autofmt_xdate()
+    path = os.path.join(out_dir, "param_drift.png")
+    fig.savefig(path, dpi=110, bbox_inches="tight"); plt.close(fig)
+    return path
+
+
+def plot_holdings_heatmap(targets: pd.DataFrame, out_dir: str) -> str:
+    """Heatmap of target weight per instrument over time (what's held when)."""
+    _ensure(out_dir)
+    fig, ax = plt.subplots(figsize=(12, 0.6 * len(targets.columns) + 2))
+    mat = targets.T  # instruments x time
+    im = ax.imshow(mat.values, aspect="auto", cmap="RdYlGn", vmin=-1.0, vmax=1.0,
+                   interpolation="nearest")
+    ax.set_yticks(range(len(mat.index))); ax.set_yticklabels([k.upper() for k in mat.index])
+    n = len(targets.index)
+    ticks = range(0, n, max(1, n // 10))
+    ax.set_xticks(list(ticks))
+    ax.set_xticklabels([targets.index[i].strftime("%Y-%m") for i in ticks], rotation=45, ha="right")
+    ax.set_title("Holdings over time (target weight per instrument)")
+    fig.colorbar(im, ax=ax, fraction=0.025, pad=0.01, label="target weight")
+    path = os.path.join(out_dir, "holdings_heatmap.png")
+    fig.savefig(path, dpi=110, bbox_inches="tight"); plt.close(fig)
+    return path
+
+
+# =============================================================================
+# Defensive trend-overlay study (research/run_overlay_study.py)
+# =============================================================================
+
+def write_overlay_report(
+    *,
+    out_dir: str,
+    window: int,
+    below: float,
+    overlay_m: dict,
+    buyhold_m: dict,
+    data_summary: dict,
+    images: list[str],
+    resolution: str,
+) -> str:
+    """Write report.md for the trend-overlay-vs-buy&hold study. The goal here is
+    risk-adjusted growth, so the table leads with drawdown / Sharpe, not win rate.
+    Metrics come from the equity curves (scale-invariant), not starting-cash %."""
+    _ensure(out_dir)
+    img_md = "\n".join(f"![{os.path.basename(p)}]({os.path.basename(p)})" for p in images)
+    below_desc = "to cash" if below == 0.0 else f"to {below:.0%} invested"
+
+    def col(m):
+        return (m['cagr'], m['sharpe'], m['max_dd_pct'], m['worst_week_pct'],
+                m['pct_winning_weeks'], m['time_in_market_pct'])
+    o = col(overlay_m)
+    b = col(buyhold_m)
+
+    md = f"""# Defensive trend overlay vs buy & hold — research backtest
+
+A broad-equity core (**SPY**) with a **{window}-day moving-average trend filter**: hold
+SPY while price is above its {window}-day SMA, otherwise step {below_desc}. This is the
+most-replicated tactical rule (time-series momentum / Faber). The goal is **smoother
+risk-adjusted growth** — cut the deep drawdowns — not to win every week.
+
+## 1. Data
+- Core: SPY ({resolution})
+- Bars: {data_summary.get('rows')} rows ({data_summary.get('span')})
+
+## 2. Results — overlay vs buy & hold
+| metric | trend overlay | buy & hold |
+|---|---|---|
+| CAGR | {_fmt(o[0], pct=True)} | {_fmt(b[0], pct=True)} |
+| Sharpe (annualised) | {_fmt(o[1])} | {_fmt(b[1])} |
+| **Max drawdown** | {_fmt(o[2], pct=True)} | {_fmt(b[2], pct=True)} |
+| Worst week | {_fmt(o[3], pct=True)} | {_fmt(b[3], pct=True)} |
+| % winning weeks | {_fmt(o[4], pct=True)} | {_fmt(b[4], pct=True)} |
+| Time in market | {_fmt(o[5], pct=True)} | {_fmt(b[5], pct=True)} |
+
+## 3. Chart
+{img_md}
+
+## 4. Read
+The overlay's edge is **risk reduction**: it sidesteps the worst of sustained
+downtrends (price below its long MA), so max drawdown shrinks and Sharpe rises,
+typically for a CAGR within a point or two of buy & hold. It does **not** raise the
+weekly win rate — it just makes the bad stretches shallower.
+
+## 5. Caveats (read these)
+- **Whipsaws in choppy/flat markets.** When price oscillates around the MA, the
+  overlay sells low and buys back higher repeatedly — a drag in range-bound years.
+- **It lags the turn.** A {window}-day MA reacts slowly; you give back some gains
+  before exiting and re-enter after the bottom.
+- **Taxes & fills not modelled.** Frequent in/out is tax-inefficient in a taxable
+  account; costs here are approximations.
+- **Backtest only.** One core asset, one rule, one history — illustrative of the
+  drawdown-reduction effect, not a guarantee.
+"""
+    path = os.path.join(out_dir, "report.md")
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(md)
+    return path
+
+
+# =============================================================================
+# Market-neutral pairs study (research/run_pairs_study.py)
+# =============================================================================
+
+def plot_spread_zscore(wide, pair, z, params, out_dir: str) -> str:
+    """Per-pair chart: the two legs normalised to 100 at the OOS start, plus the
+    spread z-score with entry/exit bands and shading where a position is open."""
+    _ensure(out_dir)
+    a = wide[f"{pair.a}_close"]
+    b = wide[f"{pair.b}_close"]
+    oos = z.loc[params.calib_end:].dropna()
+    if len(oos) < 2:
+        oos = z.dropna()
+    start = oos.index[0]
+    az = a.loc[start:]
+    bz = b.loc[start:]
+    zz = z.loc[start:]
+
+    fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(12, 7), sharex=True, height_ratios=[2, 1.4])
+    ax1.plot(az.index, az / az.iloc[0] * 100.0, color="#1f77b4", lw=1.1, label=pair.a.upper())
+    ax1.plot(bz.index, bz / bz.iloc[0] * 100.0, color="#ff7f0e", lw=1.1, label=pair.b.upper())
+    ax1.set_title(f"{pair.a.upper()} vs {pair.b.upper()}  (β={pair.beta:.2f}, coint p={pair.pvalue:.3f}) "
+                  f"— normalised = 100 at OOS start")
+    ax1.legend(loc="upper left"); ax1.grid(alpha=0.3); ax1.set_ylabel("price (=100)")
+
+    ax2.plot(zz.index, zz.values, color="#2ca02c", lw=1.0, label="spread z-score")
+    for lvl, c in ((params.entry_z, "red"), (-params.entry_z, "red"),
+                   (params.exit_z, "#888"), (-params.exit_z, "#888"),
+                   (params.stop_z, "#7a0000"), (-params.stop_z, "#7a0000")):
+        ax2.axhline(lvl, color=c, lw=0.8, ls="--", alpha=0.7)
+    ax2.axhline(0, color="k", lw=0.6)
+    # shade where |z| is beyond the entry band (a position is open / opening)
+    ax2.fill_between(zz.index, -params.entry_z, params.entry_z, color="#cccccc", alpha=0.25)
+    ax2.set_ylabel("z"); ax2.grid(alpha=0.3); ax2.legend(loc="upper left")
+    fig.autofmt_xdate()
+    path = os.path.join(out_dir, f"spread_{pair.a}_{pair.b}.png")
+    fig.savefig(path, dpi=110, bbox_inches="tight"); plt.close(fig)
+    return path
+
+
+def _weekly_table(label_strat: str, strat: dict, base: dict) -> str:
+    """Two-column weekly-consistency table (strategy vs a reference)."""
+    def row(name, key, pct=False, suffix=""):
+        sv = _fmt(strat.get(key, 0.0), pct=pct)
+        bv = _fmt(base.get(key, 0.0), pct=pct)
+        return f"| {name} | {sv}{suffix} | {bv}{suffix} |\n"
+    return (
+        f"| weekly metric | {label_strat} | buy & hold |\n|---|---|---|\n"
+        + f"| Active weeks | {strat.get('n_active_weeks')}/{strat.get('n_weeks')} "
+          f"| {base.get('n_active_weeks')}/{base.get('n_weeks')} |\n"
+        + row("% winning weeks", "pct_winning_weeks", pct=True)
+        + row("Avg week", "avg_week_pct", pct=True)
+        + row("Avg WIN week", "avg_win_week_pct", pct=True)
+        + row("Avg LOSS week", "avg_loss_week_pct", pct=True)
+        + row("Win/loss size ratio", "win_loss_ratio")
+        + row("Best week", "best_week_pct", pct=True)
+        + row("Worst week", "worst_week_pct", pct=True)
+        + f"| Longest losing streak | {strat.get('max_losing_streak_weeks')}w "
+          f"| {base.get('max_losing_streak_weeks')}w |\n"
+        + row("Weekly Sharpe", "weekly_sharpe")
+    )
+
+
+def write_pairs_report(
+    *,
+    out_dir: str,
+    stats: dict,
+    baseline_return_pct: float,
+    strat_weekly: dict,
+    base_weekly: dict,
+    spy_corr: float,
+    pairs: list,
+    data_summary: dict,
+    images: list[str],
+    params,
+    resolution: str,
+) -> str:
+    """Write report.md for the market-neutral pairs study."""
+    _ensure(out_dir)
+    img_md = "\n".join(f"![{os.path.basename(p)}]({os.path.basename(p)})" for p in images)
+    pairs_md = "| pair | hedge β | coint p-value | in-sample corr |\n|---|---|---|---|\n" + "".join(
+        f"| {p.a.upper()}–{p.b.upper()} | {p.beta:.2f} | {p.pvalue:.3f} | {p.corr:.2f} |\n"
+        for p in pairs
+    )
+
+    md = f"""# Market-neutral cross-sector pairs — research backtest
+
+Long the laggard leg, short the leader leg, bet the **spread reverts**. Pairs are
+chosen on the calibration window by **return correlation + Engle-Granger
+cointegration** (so only statistically mean-reverting spreads are traded), then
+the rolling spread z-score is traded **out-of-sample**. Each pair is dollar-neutral
+(≈ ${params.dollar_per_leg:,.0f} per leg), so the book carries little market direction.
+
+## 1. Data
+- Universe: {data_summary.get('n_universe')} instruments (stocks + sector ETFs)
+- Resolution: **{resolution}**
+- Bars: {data_summary.get('rows')} aligned rows ({data_summary.get('span')})
+- Selection window (in-sample): start → {params.calib_end}; everything after is OOS.
+
+## 2. Selected pairs (disjoint, top {params.top_pairs} by cointegration)
+{pairs_md}
+
+## 3. Signal
+- Spread = log(A) − β·log(B); rolling z over **{params.z_lookback}** bars.
+- Enter at **|z| > {params.entry_z}**, flatten at **|z| < {params.exit_z}** (hysteresis).
+- **Divergence stop at |z| > {params.stop_z}**: bail if the spread blows out (de-cohering)
+  and stay out until it normalises — caps the fat-tail loss weeks.
+
+## 4. Out-of-sample results
+| metric | value |
+|---|---|
+| Net PnL | ${_fmt(stats['net_pnl'])} |
+| Return | {_fmt(stats['return_pct'], pct=True)} |
+| Long-basket buy & hold (ref) | {_fmt(baseline_return_pct, pct=True)} |
+| Sharpe (annualised) | {_fmt(stats['sharpe'])} |
+| Max drawdown | ${_fmt(stats['max_drawdown'])} ({_fmt(stats['max_drawdown_pct'], pct=True)}) |
+| Trades | {stats['n_trades']} |
+| **Trades / week** | {_fmt(stats['trades_per_week'])} |
+| Hit rate | {_fmt(stats['hit_rate'] * 100, pct=True)} |
+| Profit factor | {_fmt(stats['profit_factor'])} |
+| Time in market | {_fmt(stats['time_in_market_pct'], pct=True)} |
+| **Weekly-return corr to SPY** | {_fmt(spy_corr)} |
+
+## 5. Weekly consistency (the goal: win most weeks)
+{_weekly_table("pairs", strat_weekly, base_weekly)}
+
+A **weekly-return correlation to SPY near 0** ({_fmt(spy_corr)}) is the point:
+profits come from spreads reverting, not from the market rising.
+
+## 6. Charts
+{img_md}
+
+## 7. Caveats (read these)
+- **Mean-reversion has fat-tail risk.** A high win rate is paid for with the
+  occasional sharp loss week when a spread keeps diverging (a leg re-rates, gets
+  acquired, or a sector breaks). Watch the **worst week** and **longest losing
+  streak** above — not just the win rate.
+- **Cointegration is in-sample.** A pair stationary over the calibration window
+  can de-cohere out-of-sample; this is the dominant failure mode of stat-arb.
+- **Costs are modelled.** Shares assume cheap commission and ~1bp slippage;
+  shorting also incurs borrow costs not modelled here.
+- **Dollar-neutral ≈ not perfectly market/beta-neutral.** Legs are balanced by
+  notional at entry, not by live beta; residual market exposure remains.
+- **Backtest only.** No live wiring; shorting + borrow handling is a later phase.
+"""
+    path = os.path.join(out_dir, "report.md")
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(md)
+    return path
+
+
+def write_portfolio_report(
+    *,
+    out_dir: str,
+    stats: dict,
+    baseline_return_pct: float,
+    params_log: pd.DataFrame,
+    data_summary: dict,
+    images: list[str],
+    cfg,
+    resolution: str,
+) -> str:
+    """Write report.md for the slow-rebuild rotation study."""
+    _ensure(out_dir)
+    img_md = "\n".join(f"![{os.path.basename(p)}]({os.path.basename(p)})" for p in images)
+    sw = int(params_log["switched"].astype(bool).sum()) if (len(params_log) and "switched" in params_log) else 0
+    n_retunes = int(len(params_log))
+
+    md = f"""# Slow-rebuild momentum/value rotation — research backtest
+
+A low-frequency rotation across a basket of equity-index "stock trackers".
+Each name is scored on **skip-recent momentum** + **value (mean-reversion)**,
+guarded by an **overextension** filter and a **long-term trend** gate, ranked
+cross-sectionally, and the top-N held. Parameters are **re-tuned on a trailing
+window every ~{cfg.walk.retune_days} bars** (the "rebuild") and held steady
+unless a new set clearly beats the incumbent — so the book turns over slowly and
+doesn't chase the freshest spike.
+
+## 1. Data
+- Basket: {data_summary.get('symbols')}
+- Resolution: **{resolution}**
+- Bars: {data_summary.get('rows')} aligned rows ({data_summary.get('span')})
+
+## 2. Configuration
+- Signals: momentum (lookback {cfg.signals.mom_lookback}, skip {cfg.signals.mom_skip}),
+  value (lookback {cfg.signals.value_lookback}), overext z>{cfg.signals.overext_z},
+  trend SMA {cfg.signals.trend_lookback}
+- Portfolio: top {cfg.portfolio.top_n}, {cfg.portfolio.weighting}-weight,
+  shorts={cfg.portfolio.allow_short}, ≤{cfg.portfolio.max_trades_per_week} trades/rebalance,
+  no-trade band {cfg.portfolio.no_trade_band}
+- Walk-forward: warmup {cfg.walk.warmup}, trailing {cfg.walk.trailing_window},
+  rebalance {cfg.walk.rebalance_days}d, re-tune {cfg.walk.retune_days}d,
+  hysteresis {cfg.walk.hysteresis}
+- Re-tunes: {n_retunes} ({sw} actually switched parameters — the rest kept the incumbent)
+
+## 3. Out-of-sample results
+| metric | value |
+|---|---|
+| Net PnL | ${_fmt(stats['net_pnl'])} |
+| Return | {_fmt(stats['return_pct'], pct=True)} |
+| Equal-weight buy & hold | {_fmt(baseline_return_pct, pct=True)} |
+| Sharpe (annualised) | {_fmt(stats['sharpe'])} |
+| Max drawdown | ${_fmt(stats['max_drawdown'])} ({_fmt(stats['max_drawdown_pct'], pct=True)}) |
+| Trades | {stats['n_trades']} |
+| **Trades / week** | {_fmt(stats['trades_per_week'])} |
+| Avg turnover / rebalance | {_fmt(stats['avg_turnover'])} |
+| Hit rate | {_fmt(stats['hit_rate'] * 100, pct=True)} |
+| Profit factor | {_fmt(stats['profit_factor'])} |
+| Time in market | {_fmt(stats['time_in_market_pct'], pct=True)} |
+
+## 4. Charts
+{img_md}
+
+## 5. Caveats (read these)
+- **Walk-forward, not look-ahead-free of bias entirely.** Parameters are chosen
+  on trailing data only (no look-ahead), but the grid, objective and guard
+  thresholds are design choices — treat results as a research signal, not proof.
+- **'Value' ≠ fundamentals.** With futures/ETF prices only, value means price vs
+  its own long-run mean (z-score), not valuation multiples.
+- **Costs are modelled, not real fills.** Per-symbol commission/slippage are
+  approximations; thin/after-hours fills would be worse.
+- **Basket is small.** A handful of correlated equity indices is a narrow
+  cross-section; momentum rotation is strongest over broader universes.
+- **Backtest only.** No live wiring — porting to a live JS Strategy behind
+  RiskManager is a separate, later phase.
+"""
+    path = os.path.join(out_dir, "report.md")
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(md)
+    return path

--- a/tools/Python/algo-py/research/result_json.py
+++ b/tools/Python/algo-py/research/result_json.py
@@ -1,0 +1,246 @@
+"""
+research/result_json.py
+
+Serialize a portfolio-study run into a JSON-able dict for the JSDemo UI bridge.
+The browser renders its own charts (Lightweight Charts), so this emits plain
+series of {time, value} with UNIX-second timestamps (ascending, unique) plus the
+stats, the per-re-tune parameter log, and a compact holdings timeline.
+
+Kept separate from report.py (which needs matplotlib) so the --json path stays
+light: pandas/numpy only.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from typing import Any
+
+import pandas as pd
+
+_EPOCH = pd.Timestamp("1970-01-01")
+
+
+def _epoch(ts: pd.Timestamp) -> int:
+    """pandas Timestamp → UNIX seconds (UTC, tz-naive safe — no local shift)."""
+    return int((pd.Timestamp(ts).normalize() - _EPOCH) / pd.Timedelta(seconds=1))
+
+
+def _num(v: Any):
+    """JSON-safe number: inf/nan → None (JSON has no inf/NaN)."""
+    try:
+        f = float(v)
+    except (TypeError, ValueError):
+        return None
+    if math.isinf(f) or math.isnan(f):
+        return None
+    return f
+
+
+def _int(v: Any) -> int:
+    """Safe int: NaN/inf/None (e.g. an early re-tune before any params qualify)
+    → 0, so JSON serialization never trips on int(NaN)."""
+    try:
+        f = float(v)
+    except (TypeError, ValueError):
+        return 0
+    if math.isnan(f) or math.isinf(f):
+        return 0
+    return int(f)
+
+
+def _series(s: pd.Series) -> list[dict]:
+    return [{"time": _epoch(ts), "value": _num(val)} for ts, val in s.items()]
+
+
+def to_result_dict(wf, result, cfg, data_summary: dict, baseline_return_pct: float) -> dict:
+    """Build the JSON payload from a WalkForwardResult + PortfolioResult."""
+    # Holdings, downsampled to rows where the book actually changes (+ the first
+    # held row) so the timeline stays compact.
+    targets = result.targets
+    keys = list(targets.columns)
+    changed = targets.diff().abs().sum(axis=1) > 1e-9
+    if len(targets):
+        changed.iloc[0] = bool((targets.iloc[0].abs().sum()) > 0) or changed.iloc[0]
+    change_idx = targets.index[changed]
+    holdings = {
+        "keys": keys,
+        "times": [_epoch(ts) for ts in change_idx],
+        "rows": [[_num(v) for v in targets.loc[ts].tolist()] for ts in change_idx],
+    }
+
+    plog = wf.params_log
+    params_log = []
+    if len(plog):
+        for ts, row in plog.iterrows():
+            params_log.append({
+                "time": _epoch(ts),
+                "mom_lookback": _int(row.get("mom_lookback")),
+                "mom_skip": _int(row.get("mom_skip")),
+                "value_lookback": _int(row.get("value_lookback")),
+                "top_n": _int(row.get("top_n")),
+                "objective": _num(row.get("objective")),
+                "switched": bool(row.get("switched", False)),
+            })
+
+    stats = {k: _num(v) if isinstance(v, (int, float)) else v for k, v in result.stats.items()}
+
+    return {
+        "ok": True,
+        "meta": {
+            "basket": keys,
+            "source": data_summary.get("source"),
+            "resolution": data_summary.get("resolution"),
+            "span": data_summary.get("span"),
+            "rows": data_summary.get("rows"),
+        },
+        "config": {
+            "mom_lookback": cfg.signals.mom_lookback,
+            "mom_skip": cfg.signals.mom_skip,
+            "value_lookback": cfg.signals.value_lookback,
+            "overext_z": cfg.signals.overext_z,
+            "trend_lookback": cfg.signals.trend_lookback,
+            "top_n": cfg.portfolio.top_n,
+            "weighting": cfg.portfolio.weighting,
+            "max_trades_per_week": cfg.portfolio.max_trades_per_week,
+            "no_trade_band": cfg.portfolio.no_trade_band,
+            "warmup": cfg.walk.warmup,
+            "trailing_window": cfg.walk.trailing_window,
+            "rebalance_days": cfg.walk.rebalance_days,
+            "retune_days": cfg.walk.retune_days,
+            "hysteresis": cfg.walk.hysteresis,
+        },
+        "stats": stats,
+        "baseline_return_pct": _num(baseline_return_pct),
+        "n_retunes": len(params_log),
+        "n_switched": int(sum(1 for p in params_log if p["switched"])),
+        "equity": _series(result.equity),
+        "baseline_equity": _series(result.baseline_equity),
+        "params_log": params_log,
+        "holdings": holdings,
+    }
+
+
+def _trades(trades: pd.DataFrame) -> list[dict]:
+    """Serialize a backtest trade blotter (one row per position change)."""
+    out = []
+    if trades is None or not len(trades):
+        return out
+    for ts, row in trades.iterrows():
+        out.append({
+            "time": _epoch(ts),
+            "from": _int(row.get("from")),
+            "to": _int(row.get("to")),
+            "price": _num(row.get("price")),
+            "realized_pnl": _num(row.get("realized_pnl")),
+        })
+    return out
+
+
+def _stats_clean(stats: dict) -> dict:
+    """JSON-safe stats dict (inf/NaN floats → None, ints/strings untouched)."""
+    return {k: (_num(v) if isinstance(v, (int, float)) else v) for k, v in stats.items()}
+
+
+def to_backtest_dict(result, buy_hold_equity, *, symbol: str, signal: str,
+                     params: dict, data_summary: dict) -> dict:
+    """Serialize a single-instrument ``backtest.BacktestResult`` for the PyDemo
+    Backtester panel. ``buy_hold_equity`` is a notionally-scaled own-the-asset line
+    (starting_cash * close/close[0]) so the comparison is meaningful regardless of
+    contract sizing (the engine's own 1-contract baseline would be tiny for shares)."""
+    return {
+        "ok": True,
+        "meta": {
+            "symbol": symbol,
+            "signal": signal,
+            "source": data_summary.get("source"),
+            "span": data_summary.get("span"),
+            "rows": data_summary.get("rows"),
+        },
+        "params": params,
+        "stats": _stats_clean(result.stats),
+        "equity": _series(result.equity),
+        "buy_hold_equity": _series(buy_hold_equity),
+        "trades": _trades(result.trades),
+    }
+
+
+def to_overlay_dict(overlay_eq, buyhold_eq, overlay_m: dict, buyhold_m: dict, *,
+                    window: int, below: float, data_summary: dict) -> dict:
+    """Serialize the defensive trend-overlay study (overlay equity vs buy & hold)."""
+    return {
+        "ok": True,
+        "meta": {
+            "study": "overlay", "window": window, "below": below,
+            "source": data_summary.get("source"),
+            "span": data_summary.get("span"),
+            "rows": data_summary.get("rows"),
+        },
+        "stats": _stats_clean(overlay_m),
+        "baseline_stats": _stats_clean(buyhold_m),
+        "equity": _series(overlay_eq),
+        "baseline_equity": _series(buyhold_eq),
+    }
+
+
+def to_war_dict(full, event_stats: dict, *, calib_info: dict, data_summary: dict) -> dict:
+    """Serialize the ES war-window combo study: full-span equity + buy&hold, plus
+    full-span and event-window stat blocks and the calibration summary."""
+    return {
+        "ok": True,
+        "meta": {
+            "study": "war",
+            "source": data_summary.get("source"),
+            "resolution": data_summary.get("resolution"),
+            "span": data_summary.get("span"),
+            "rows": data_summary.get("rows"),
+            "event_start": data_summary.get("event_start"),
+            "event_end": data_summary.get("event_end"),
+        },
+        "calib": calib_info,
+        "stats": _stats_clean(full.stats),
+        "event_stats": _stats_clean(event_stats),
+        "equity": _series(full.equity),
+        "buy_hold_equity": _series(full.buy_hold_equity),
+    }
+
+
+def to_pairs_dict(result, *, pairs, zscores: dict, strat_weekly: dict,
+                  base_weekly: dict, spy_corr: float, baseline_return_pct: float,
+                  params, data_summary: dict) -> dict:
+    """Serialize the market-neutral pairs study: portfolio equity vs buy&hold, the
+    weekly-consistency lens, SPY-neutrality, and per-pair stats + z-score series."""
+    pair_rows = []
+    for p in pairs:
+        pair_rows.append({
+            "label": p.label,
+            "a": p.a, "b": p.b,
+            "beta": _num(p.beta),
+            "pvalue": _num(p.pvalue),
+            "corr": _num(p.corr),
+            "zscore": _series(zscores[p.label].dropna()) if p.label in zscores else [],
+        })
+    return {
+        "ok": True,
+        "meta": {
+            "study": "pairs",
+            "source": data_summary.get("source"),
+            "n_universe": data_summary.get("n_universe"),
+            "span": data_summary.get("span"),
+            "rows": data_summary.get("rows"),
+            "entry_z": params.entry_z, "exit_z": params.exit_z, "stop_z": params.stop_z,
+        },
+        "stats": _stats_clean(result.stats),
+        "baseline_return_pct": _num(baseline_return_pct),
+        "spy_corr": _num(spy_corr),
+        "weekly": _stats_clean(strat_weekly),
+        "baseline_weekly": _stats_clean(base_weekly),
+        "equity": _series(result.equity),
+        "baseline_equity": _series(result.baseline_equity),
+        "pairs": pair_rows,
+    }
+
+
+def write_json(path: str, obj: dict) -> None:
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(obj, f)

--- a/tools/Python/algo-py/research/run_backtest.py
+++ b/tools/Python/algo-py/research/run_backtest.py
@@ -1,0 +1,133 @@
+"""
+research/run_backtest.py
+
+Single-instrument backtest runner — surfaces the audited `backtest.backtest()`
+engine (one-bar lag, cost model, trade blotter, PnL reconciliation) for ONE symbol
+and one signal, and emits a machine-readable JSON result for the PyDemo Backtester
+panel. No new strategy math: the target series is built by REUSING the signal
+functions in `model.py` (momentum / mean-reversion), the same ones the war study uses.
+
+    # CSV (default; reads research/data_csv/{symbol}.csv) — no token, no network
+    python -m research.run_backtest --symbol spy --signal momentum --json out.json
+    python -m research.run_backtest --symbol aapl --signal mean_reversion --json out.json
+
+    # Free real data from Yahoo
+    python -m research.run_backtest --symbol qqq --source yahoo --signal momentum --json out.json
+
+Without --json it prints the stats to stdout (handy for a quick CLI check).
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import os
+import sys
+
+import pandas as pd
+
+from . import config, data, model as model_mod, result_json
+from .backtest import backtest
+
+SIGNALS = ("momentum", "mean_reversion")
+
+
+def _load_close(symbol: str, source: str, csv_dir: str, start: str, end: str) -> pd.Series:
+    """Load one instrument's close series from CSV or Yahoo. CSV reads
+    {csv_dir}/{symbol}.csv directly (any OHLCV file load_csv_symbol understands),
+    so the symbol need not be in config.SYMBOLS."""
+    if source == "csv":
+        path = os.path.join(csv_dir, f"{symbol}.csv")
+        if not os.path.exists(path):
+            raise RuntimeError(
+                f"No CSV for {symbol!r} at {path}. Expected {symbol}.csv in {csv_dir} "
+                f"(or use --source yahoo)."
+            )
+        df = data.load_csv_symbol(path)
+    else:
+        sym = config.Symbol(symbol, symbol.upper(), symbol.upper(),
+                            ["ARCA", "NASDAQ", "NYSE"], yahoo=symbol.upper())
+        df = data.fetch_yahoo_symbol(sym, start=start, end=end)
+    close = df["close"].astype(float)
+    if len(close) < 30:
+        raise RuntimeError(f"{symbol}: only {len(close)} bars — too few to backtest.")
+    return close
+
+
+def _build_target(close: pd.Series, signal: str, zscore_lookback: int) -> pd.Series:
+    if signal == "momentum":
+        return model_mod.momentum_score(close, config.DEFAULT.indicators)
+    if signal == "mean_reversion":
+        return model_mod.mean_reversion_score(close, zscore_lookback)
+    raise RuntimeError(f"unknown signal {signal!r}; choose from {SIGNALS}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    try:
+        sys.stdout.reconfigure(encoding="utf-8")
+    except Exception:
+        pass
+
+    ap = argparse.ArgumentParser(description="Single-instrument signal backtest")
+    ap.add_argument("--symbol", default="spy", help="instrument key (CSV file name / Yahoo ticker), e.g. spy")
+    ap.add_argument("--source", choices=["csv", "yahoo"], default="csv",
+                    help="data source (default: csv — reads research/data_csv/{symbol}.csv)")
+    ap.add_argument("--csv-dir", default=os.path.join(os.path.dirname(__file__), "data_csv"))
+    ap.add_argument("--signal", choices=list(SIGNALS), default="momentum")
+    ap.add_argument("--zscore-lookback", type=int, default=config.DEFAULT.indicators.zscore_lookback,
+                    help="mean_reversion lookback in bars (default 252)")
+    ap.add_argument("--start", default="2018-01-01")
+    ap.add_argument("--end", default=config.FETCH_END)
+    ap.add_argument("--json", dest="json_path", default=None,
+                    help="write the result as JSON to this path (for the PyDemo panel)")
+    args = ap.parse_args(argv)
+
+    try:
+        close = _load_close(args.symbol, args.source, args.csv_dir, args.start, args.end)
+    except RuntimeError as e:
+        print(f"[backtest] ERROR: {e}", file=sys.stderr)
+        return 2
+
+    target = _build_target(close, args.signal, args.zscore_lookback).reindex(close.index)
+
+    # Size as an equity/share position: point_value = $1, and a |target|=1 deploys
+    # ~the full starting cash (max_contracts ≈ cash / price), so equity is on the
+    # same scale as a buy & hold of the same capital.
+    ref = float(close.iloc[0])
+    mc = max(1, int(round(config.CostModel().starting_cash / ref))) if ref > 0 else 1
+    costs = dataclasses.replace(config.PORTFOLIO_BASE_COST, point_value=1.0, max_contracts=mc)
+    cfg = dataclasses.replace(config.DEFAULT, costs=costs)
+
+    result = backtest(close, target, cfg)
+
+    # Comparable own-the-asset baseline: all starting cash in the symbol on day 1.
+    buy_hold = costs.starting_cash * (close / float(close.iloc[0]))
+
+    print(f"[backtest] {args.symbol} / {args.signal}: {len(close)} bars "
+          f"({close.index.min().date()}..{close.index.max().date()})")
+    print(f"[backtest] stats: {result.stats}")
+
+    if args.json_path:
+        data_summary = {
+            "source": args.source,
+            "rows": int(len(close)),
+            "span": f"{close.index.min().date()} → {close.index.max().date()}",
+        }
+        params = {
+            "signal": args.signal,
+            "zscore_lookback": args.zscore_lookback,
+            "max_contracts": mc,
+            "point_value": 1.0,
+            "starting_cash": costs.starting_cash,
+        }
+        obj = result_json.to_backtest_dict(
+            result, buy_hold, symbol=args.symbol, signal=args.signal,
+            params=params, data_summary=data_summary,
+        )
+        result_json.write_json(args.json_path, obj)
+        print(f"[backtest] wrote JSON -> {args.json_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/Python/algo-py/research/run_overlay_study.py
+++ b/tools/Python/algo-py/research/run_overlay_study.py
@@ -1,0 +1,163 @@
+"""
+research/run_overlay_study.py
+
+Defensive trend-overlay study: a broad-equity core (SPY) with a moving-average
+trend filter — hold SPY while price is above its N-day SMA, otherwise step to cash
+(or a reduced weight). This is the most-replicated tactical rule (time-series
+momentum / Faber). The point is SMOOTHER RISK-ADJUSTED GROWTH (shallower drawdowns,
+higher Sharpe), NOT a higher weekly win rate.
+
+It reuses the same engine as the other studies: a causal SMA signal (acted on with
+the backtester's one-bar lag, so no look-ahead) fed through
+`multi_backtest.backtest_portfolio`, whose equal-weight baseline is continuous
+full-SPY = buy & hold.
+
+    python -m research.run_overlay_study --source csv --sma 200
+    python -m research.run_overlay_study --source yahoo --sma 200 --below 0.5
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import os
+import sys
+
+import numpy as np
+import pandas as pd
+
+from . import config, data, indicators, multi_backtest, report, result_json
+
+
+def equity_metrics(equity: pd.Series, time_in_market: float) -> dict:
+    """Scale-invariant performance from an equity curve (so the growing fixed-share
+    position size doesn't distort %-of-starting-cash figures): CAGR, Sharpe and max
+    drawdown from daily equity returns, plus weekly win rate / worst week."""
+    rets = equity.pct_change().dropna()
+    years = (equity.index[-1] - equity.index[0]).days / 365.25
+    cagr = (float((equity.iloc[-1] / equity.iloc[0]) ** (1.0 / years) - 1.0) * 100.0
+            if years > 0 and equity.iloc[0] > 0 else 0.0)
+    sharpe = float(np.sqrt(252) * rets.mean() / rets.std(ddof=0)) if rets.std(ddof=0) > 0 else 0.0
+    max_dd = float((equity / equity.cummax() - 1.0).min() * 100.0)
+    wk = (equity.resample("W").last().pct_change().dropna() * 100.0)
+    return {
+        "cagr": cagr,
+        "sharpe": sharpe,
+        "max_dd_pct": max_dd,
+        "pct_winning_weeks": float((wk > 0).mean() * 100.0) if len(wk) else 0.0,
+        "worst_week_pct": float(wk.min()) if len(wk) else 0.0,
+        "time_in_market_pct": time_in_market,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    try:
+        sys.stdout.reconfigure(encoding="utf-8")
+    except Exception:
+        pass
+
+    ap = argparse.ArgumentParser(description="Defensive trend-overlay vs buy & hold study")
+    ap.add_argument("--source", choices=["csv", "yahoo"], default="csv", help="data source (default: csv; SPY is cached)")
+    ap.add_argument("--csv-dir", default=os.path.join(os.path.dirname(__file__), "data_csv"))
+    ap.add_argument("--start", default="2018-01-01")
+    ap.add_argument("--end", default=config.FETCH_END)
+    ap.add_argument("--sma", type=int, default=200, help="trend-filter SMA window in bars (default 200)")
+    ap.add_argument("--below", type=float, default=0.0, help="invested fraction when below the SMA (0=cash)")
+    ap.add_argument("--out", default=os.path.join(os.path.dirname(__file__), "output_overlay"))
+    ap.add_argument("--json", dest="json_path", default=None,
+                    help="write the result as JSON to this path (for the PyDemo panel)")
+    args = ap.parse_args(argv)
+
+    core = config.SPY
+    if args.source == "csv":
+        resolution = "csv (as provided)"
+        try:
+            frames = data.load_csv_all(args.csv_dir, symbols=[core])
+        except RuntimeError as e:
+            print(f"[overlay] ERROR: {e}", file=sys.stderr)
+            return 2
+    else:
+        resolution = "1-day (Yahoo, adjusted)"
+        print(f"[overlay] downloading {core.yahoo_ticker} from Yahoo {args.start}..{args.end}")
+        try:
+            frames = data.fetch_yahoo_all(symbols=[core], start=args.start, end=args.end)
+        except RuntimeError as e:
+            print(f"[overlay] ERROR: {e}", file=sys.stderr)
+            return 2
+
+    close = frames[core.key]["close"]
+    print(f"[overlay] SPY: {len(close)} bars ({close.index.min().date()}..{close.index.max().date()})")
+
+    # Causal trend signal: invested when close > SMA(window), else `below`. The
+    # backtester lags positions one bar, so this acts on the prior close — no look-ahead.
+    sma = indicators.sma(close, args.sma)
+    overlay = pd.Series(np.where(close > sma, 1.0, args.below), index=close.index)
+    overlay = overlay.where(sma.notna(), 0.0)  # flat during the SMA warmup
+    targets = pd.DataFrame({core.key: overlay})
+
+    # Size so target=1.0 deploys ~ the full $100k (comparable to buy & hold).
+    ref = float(close.iloc[0])
+    mc = max(1, int(round(config.CostModel().starting_cash / ref)))
+    costs = {core.key: dataclasses.replace(config.cost_for(core.key), max_contracts=mc)}
+
+    cfg = config.DEFAULT
+    result = multi_backtest.backtest_portfolio(targets, {core.key: close}, cfg, costs_by_key=costs)
+    starting = cfg.costs.starting_cash
+
+    # Compare both over the SAME window — from the first bar the overlay can trade
+    # (after the SMA warmup) — against a TRUE day-1 buy & hold curve built straight
+    # from price (the engine's baseline sits flat through the warmup, which would
+    # deflate buy & hold's CAGR/weekly stats).
+    start = sma.first_valid_index()
+    overlay_eq = result.equity.loc[start:]
+    buyhold_eq = starting * (close.loc[start:] / float(close.loc[start]))
+
+    overlay_m = equity_metrics(overlay_eq, result.stats["time_in_market_pct"])
+    buyhold_m = equity_metrics(buyhold_eq, 100.0)
+
+    # JSON path (for the PyDemo Research hub): emit machine-readable results, no PNGs.
+    if args.json_path:
+        data_summary = {
+            "source": args.source, "rows": int(len(close)),
+            "span": f"{close.index.min().date()} → {close.index.max().date()}",
+        }
+        obj = result_json.to_overlay_dict(
+            overlay_eq, buyhold_eq, overlay_m, buyhold_m,
+            window=args.sma, below=args.below, data_summary=data_summary,
+        )
+        result_json.write_json(args.json_path, obj)
+        print(f"[overlay] wrote JSON -> {args.json_path}")
+        return 0
+
+    print(f"[overlay] SMA window={args.sma}, below={args.below}  (metrics from equity curve)")
+    print(f"[overlay] CAGR:           overlay {overlay_m['cagr']:+.2f}%   vs  buy&hold {buyhold_m['cagr']:+.2f}%")
+    print(f"[overlay] Sharpe:         overlay {overlay_m['sharpe']:.2f}     vs  buy&hold {buyhold_m['sharpe']:.2f}")
+    print(f"[overlay] max drawdown:   overlay {overlay_m['max_dd_pct']:.1f}%  vs  buy&hold {buyhold_m['max_dd_pct']:.1f}%")
+    print(f"[overlay] worst week:     overlay {overlay_m['worst_week_pct']:+.2f}%  vs  buy&hold {buyhold_m['worst_week_pct']:+.2f}%")
+    print(f"[overlay] winning weeks:  overlay {overlay_m['pct_winning_weeks']:.1f}%   vs  buy&hold {buyhold_m['pct_winning_weeks']:.1f}%")
+    print(f"[overlay] time in market: overlay {overlay_m['time_in_market_pct']:.1f}%  vs  buy&hold {buyhold_m['time_in_market_pct']:.1f}%")
+
+    out_dir = args.out
+    try:
+        os.makedirs(out_dir, exist_ok=True)
+        pd.DataFrame({"overlay_equity": overlay_eq, "buyhold_equity": buyhold_eq}).to_csv(
+            os.path.join(out_dir, "pnl.csv"))
+    except Exception:
+        pass
+
+    images = [report.plot_portfolio_equity(
+        overlay_eq, buyhold_eq, out_dir,
+        label=f"SPY + {args.sma}d trend overlay", baseline_label="SPY buy & hold",
+        title="Equity ($) — trend overlay vs buy & hold")]
+    data_summary = {"rows": len(close), "span": f"{close.index.min().date()} → {close.index.max().date()}"}
+    path = report.write_overlay_report(
+        out_dir=out_dir, window=args.sma, below=args.below,
+        overlay_m=overlay_m, buyhold_m=buyhold_m,
+        data_summary=data_summary, images=images, resolution=resolution,
+    )
+    print(f"[overlay] wrote report -> {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/Python/algo-py/research/run_pairs_study.py
+++ b/tools/Python/algo-py/research/run_pairs_study.py
@@ -1,0 +1,201 @@
+"""
+research/run_pairs_study.py
+
+Orchestrates the market-neutral cross-sector pairs study:
+
+    fetch/align universe  →  select cointegrated pairs (in-sample)
+                          →  trade spread z-score (out-of-sample)
+                          →  weekly-consistency lens + SPY-neutrality check  →  report
+
+The point of this study is WEEKLY CONSISTENCY, not max return: long the laggard
+leg, short the leader leg, profit when the spread reverts — so the weekly win rate
+is driven by mean-reversion, not by the market going up (weekly corr to SPY ≈ 0).
+
+    # Real data from Yahoo (default), select on <=2021, trade 2022+ OOS
+    python -m research.run_pairs_study --source yahoo --start 2018-01-01 --end 2025-06-30
+
+    # Reuse cached CSVs (after a --cache-csv run); needs one CSV per universe key
+    python -m research.run_pairs_study --source csv
+
+Outputs land in research/output_pairs/ (report.md + PNGs).
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import os
+import sys
+
+import numpy as np
+import pandas as pd
+
+from . import config, data, multi_backtest, pairs as pairs_mod, report, result_json
+
+
+def _weekly_returns(pnl: pd.Series, starting: float) -> pd.Series:
+    return (pnl.resample("W").sum() / starting).dropna()
+
+
+def main(argv: list[str] | None = None) -> int:
+    # Windows consoles default to cp1252; keep prints from crashing on any non-ASCII.
+    try:
+        sys.stdout.reconfigure(encoding="utf-8")
+    except Exception:
+        pass
+
+    ap = argparse.ArgumentParser(description="Market-neutral cross-sector pairs study")
+    ap.add_argument("--source", choices=["csv", "yahoo"], default="yahoo", help="data source (default: yahoo)")
+    ap.add_argument("--universe", choices=["pairs", "large"], default="pairs",
+                    help="pairs=~24 names, large=~80 liquid names + ETFs (more cointegrated pairs)")
+    ap.add_argument("--csv-dir", default=os.path.join(os.path.dirname(__file__), "data_csv"))
+    ap.add_argument("--cache-csv", action="store_true", help="yahoo: also write pulled data to --csv-dir")
+    ap.add_argument("--start", default="2018-01-01", help="fetch start (default 2018-01-01)")
+    ap.add_argument("--end", default=config.FETCH_END, help=f"fetch end (default {config.FETCH_END})")
+    ap.add_argument("--calib-end", default=config.DEFAULT.pairs.calib_end,
+                    help="in-sample/out-of-sample split (pairs selected on data up to here)")
+    ap.add_argument("--top-pairs", type=int, default=config.DEFAULT.pairs.top_pairs)
+    ap.add_argument("--entry-z", type=float, default=config.DEFAULT.pairs.entry_z)
+    ap.add_argument("--exit-z", type=float, default=config.DEFAULT.pairs.exit_z)
+    ap.add_argument("--stop-z", type=float, default=config.DEFAULT.pairs.stop_z,
+                    help="divergence stop: bail when |z| exceeds this (use a big number to disable)")
+    ap.add_argument("--z-lookback", type=int, default=config.DEFAULT.pairs.z_lookback)
+    ap.add_argument("--min-corr", type=float, default=config.DEFAULT.pairs.min_corr)
+    ap.add_argument("--max-pvalue", type=float, default=config.DEFAULT.pairs.max_pvalue)
+    ap.add_argument("--dollar-per-leg", type=float, default=config.DEFAULT.pairs.dollar_per_leg)
+    ap.add_argument("--out", default=os.path.join(os.path.dirname(__file__), "output_pairs"))
+    ap.add_argument("--json", dest="json_path", default=None,
+                    help="write the result as JSON to this path (for the PyDemo panel)")
+    args = ap.parse_args(argv)
+
+    params = dataclasses.replace(
+        config.DEFAULT.pairs, calib_end=args.calib_end, top_pairs=args.top_pairs,
+        entry_z=args.entry_z, exit_z=args.exit_z, stop_z=args.stop_z, z_lookback=args.z_lookback,
+        min_corr=args.min_corr, max_pvalue=args.max_pvalue, dollar_per_leg=args.dollar_per_leg,
+    )
+    universe = config.LARGE_UNIVERSE if args.universe == "large" else config.PAIRS_UNIVERSE
+    fetch_syms = universe + [config.SPY]  # SPY = market-neutrality reference
+
+    # --- data ---------------------------------------------------------------
+    if args.source == "csv":
+        resolution = "csv (as provided)"
+        print(f"[pairs] loading CSVs from {args.csv_dir} for {len(fetch_syms)} symbols")
+        try:
+            frames = data.load_csv_all(args.csv_dir, symbols=fetch_syms)
+        except RuntimeError as e:
+            print(f"[pairs] ERROR: {e}", file=sys.stderr)
+            return 2
+    else:
+        resolution = "1-day (Yahoo, adjusted)"
+        print(f"[pairs] downloading {len(fetch_syms)} symbols from Yahoo {args.start}..{args.end}")
+        try:
+            frames = data.fetch_yahoo_all(symbols=fetch_syms, start=args.start, end=args.end)
+        except RuntimeError as e:
+            print(f"[pairs] ERROR: {e}", file=sys.stderr)
+            return 2
+        if args.cache_csv:
+            data.save_frames_csv(frames, args.csv_dir)
+            print(f"[pairs] cached CSVs -> {args.csv_dir}")
+
+    wide = data.align(frames)
+    if wide.empty:
+        print("[pairs] ERROR: no overlapping data across the universe after alignment.", file=sys.stderr)
+        return 2
+    print(f"[pairs] aligned rows: {len(wide)} ({wide.index.min().date()}..{wide.index.max().date()})")
+
+    closes = {s.key: wide[f"{s.key}_close"] for s in universe}
+    spy_close = wide["spy_close"]
+
+    # --- select pairs (in-sample) ------------------------------------------
+    print(f"[pairs] selecting pairs on data up to {params.calib_end} "
+          f"(min_corr={params.min_corr}, max_pvalue={params.max_pvalue})...")
+    pairs = pairs_mod.select_pairs(closes, params)
+    if not pairs:
+        print("[pairs] ERROR: no cointegrated pairs found. Loosen --min-corr / --max-pvalue.", file=sys.stderr)
+        return 2
+    print(f"[pairs] selected {len(pairs)} disjoint pairs:")
+    for p in pairs:
+        print(f"[pairs]   {p.a.upper():>5}-{p.b.upper():<5}  beta={p.beta:+.2f}  coint_p={p.pvalue:.3f}  corr={p.corr:.2f}")
+
+    # --- build targets + dollar-neutral sizing, backtest OOS ----------------
+    targets, zscores = pairs_mod.build_targets(wide, pairs, params)
+    costs = pairs_mod.dollar_neutral_costs(wide, pairs, params)
+    leg_closes = {k: closes[k] for k in targets.columns}
+
+    cfg = config.DEFAULT
+    result = multi_backtest.backtest_portfolio(targets, leg_closes, cfg, costs_by_key=costs)
+    print(f"[pairs] OOS stats: {result.stats}")
+
+    starting = cfg.costs.starting_cash
+    baseline_return_pct = float((result.baseline_equity.iloc[-1] - starting) / starting * 100.0)
+
+    # --- weekly consistency + SPY-neutrality --------------------------------
+    base_pnl = result.baseline_equity.diff().fillna(0.0)
+    strat_wk = multi_backtest.weekly_consistency(result.pnl, starting)
+    base_wk = multi_backtest.weekly_consistency(base_pnl, starting)
+
+    # Weekly-return correlation to SPY over the OOS span (≈0 ⇒ market-neutral).
+    strat_w = _weekly_returns(result.pnl.loc[params.calib_end:], starting)
+    spy_w = spy_close.loc[params.calib_end:].resample("W").last().pct_change()
+    join = pd.concat([strat_w.rename("s"), spy_w.rename("spy")], axis=1).dropna()
+    join = join[join["s"] != 0.0]  # only weeks the strategy was active
+    spy_corr = float(join["s"].corr(join["spy"])) if len(join) > 2 else float("nan")
+
+    print("[pairs] --- weekly consistency (pairs vs buy&hold) ---")
+    print(f"[pairs]   active weeks:    {strat_wk['n_active_weeks']}/{strat_wk['n_weeks']}  vs  {base_wk['n_active_weeks']}/{base_wk['n_weeks']}")
+    print(f"[pairs]   winning weeks:   {strat_wk['pct_winning_weeks']:.1f}%  vs  {base_wk['pct_winning_weeks']:.1f}%")
+    print(f"[pairs]   avg week:        {strat_wk['avg_week_pct']:+.3f}%  vs  {base_wk['avg_week_pct']:+.3f}%")
+    print(f"[pairs]   avg WIN week:    {strat_wk['avg_win_week_pct']:+.3f}%  vs  {base_wk['avg_win_week_pct']:+.3f}%")
+    print(f"[pairs]   avg LOSS week:   {strat_wk['avg_loss_week_pct']:+.3f}%  vs  {base_wk['avg_loss_week_pct']:+.3f}%")
+    print(f"[pairs]   worst week:      {strat_wk['worst_week_pct']:+.3f}%  vs  {base_wk['worst_week_pct']:+.3f}%")
+    print(f"[pairs]   longest losing streak: {strat_wk['max_losing_streak_weeks']}w  vs  {base_wk['max_losing_streak_weeks']}w")
+    print(f"[pairs]   weekly Sharpe:   {strat_wk['weekly_sharpe']:.2f}    vs  {base_wk['weekly_sharpe']:.2f}")
+    print(f"[pairs]   weekly-return corr to SPY: {spy_corr:.2f}  (~0 => market-neutral)")
+
+    # JSON path (for the PyDemo Research hub): emit machine-readable results, no PNGs.
+    if args.json_path:
+        data_summary = {
+            "source": args.source, "n_universe": len(universe), "rows": len(wide),
+            "span": f"{wide.index.min().date()} → {wide.index.max().date()}",
+        }
+        obj = result_json.to_pairs_dict(
+            result, pairs=pairs, zscores=zscores, strat_weekly=strat_wk,
+            base_weekly=base_wk, spy_corr=spy_corr, baseline_return_pct=baseline_return_pct,
+            params=params, data_summary=data_summary,
+        )
+        result_json.write_json(args.json_path, obj)
+        print(f"[pairs] wrote JSON -> {args.json_path}")
+        return 0
+
+    # --- report -------------------------------------------------------------
+    out_dir = args.out
+    try:
+        os.makedirs(out_dir, exist_ok=True)
+        pd.DataFrame({"strategy": result.pnl, "buyhold": base_pnl}).to_csv(os.path.join(out_dir, "pnl.csv"))
+    except Exception:
+        pass
+
+    images = [
+        report.plot_portfolio_equity(result.equity, result.baseline_equity, out_dir),
+        report.plot_holdings_heatmap(result.targets, out_dir),
+    ]
+    for p in pairs:
+        images.append(report.plot_spread_zscore(wide, p, zscores[p.label], params, out_dir))
+
+    data_summary = {
+        "n_universe": len(universe),
+        "rows": len(wide),
+        "span": f"{wide.index.min().date()} → {wide.index.max().date()}",
+    }
+    path = report.write_pairs_report(
+        out_dir=out_dir, stats=result.stats, baseline_return_pct=baseline_return_pct,
+        strat_weekly=strat_wk, base_weekly=base_wk, spy_corr=spy_corr, pairs=pairs,
+        data_summary=data_summary, images=images, params=params, resolution=resolution,
+    )
+    print(f"[pairs] wrote report -> {path}")
+    print(f"[pairs] artifacts in {out_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/Python/algo-py/research/run_portfolio_study.py
+++ b/tools/Python/algo-py/research/run_portfolio_study.py
@@ -1,0 +1,205 @@
+"""
+research/run_portfolio_study.py
+
+Orchestrates the slow-rebuild rotation study:
+
+    fetch/align basket  →  walk-forward re-tune  →  multi-asset OOS backtest  →  report
+
+Two data sources (CSV is the default; the T4 barchart currently 400s — see
+probe_data.py):
+
+    # CSV (default) — drop one Yahoo Finance OHLCV export per basket member into
+    # research/data_csv/, named by key: spy.csv / qqq.csv / dia.csv / iwm.csv
+    python -m research.run_portfolio_study
+    python -m research.run_portfolio_study --csv-dir /path/to/csvs
+
+    # Futures basket via T4 (once the barchart 400 is sorted)
+    export T4_API_TOKEN=...
+    python -m research.run_portfolio_study --source t4 --basket futures
+
+Outputs land in research/output_portfolio/ (report.md + PNGs).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+from . import config, data, multi_backtest, portfolio as pf, report, result_json, walkforward
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Slow-rebuild momentum/value rotation study")
+    ap.add_argument("--source", choices=["csv", "yahoo", "t4"], default="csv", help="data source (default: csv)")
+    ap.add_argument("--basket", choices=["etf", "futures"], default="etf",
+                    help="etf=SPY/QQQ/DIA/IWM, futures=ES/NQ/YM/RTY")
+    ap.add_argument("--keys", default=None,
+                    help="comma-separated subset of basket keys to actually run "
+                         "(e.g. 'es,nq,rty' to drop an instrument with no data). "
+                         "Defaults to the whole basket.")
+    ap.add_argument("--csv-dir", default=os.path.join(os.path.dirname(__file__), "data_csv"),
+                    help="directory of per-key CSVs (csv source)")
+    ap.add_argument("--cache-csv", action="store_true",
+                    help="yahoo only: also write the pulled data to --csv-dir for offline reruns")
+    ap.add_argument("--start", default=config.FETCH_START,
+                    help=f"yahoo/t4: fetch start (default {config.FETCH_START}). "
+                         "The walk-forward needs >warmup+retune bars, so a multi-year "
+                         "span gives a meaningful out-of-sample window.")
+    ap.add_argument("--end", default=config.FETCH_END,
+                    help=f"yahoo/t4: fetch end (default {config.FETCH_END})")
+    ap.add_argument("--gross-target", type=float, default=config.DEFAULT.portfolio.gross_target,
+                    help="sum of |target| spread across held names (default "
+                         f"{config.DEFAULT.portfolio.gross_target}). Each name is still "
+                         "clipped to |1.0|, so the effective max is top_n * 1.0.")
+    ap.add_argument("--max-contracts", type=int, default=config.PORTFOLIO_BASE_COST.max_contracts,
+                    help="contracts/shares at |target|=1.0 (default "
+                         f"{config.PORTFOLIO_BASE_COST.max_contracts}). This is the real "
+                         "capital-deployment lever; raise it with --gross-target to invest more.")
+    ap.add_argument("--intraday", action="store_true", help="T4 only: Minute bars instead of Day")
+    ap.add_argument("--out", default=os.path.join(os.path.dirname(__file__), "output_portfolio"))
+    ap.add_argument("--json", dest="json_path", default=None,
+                    help="write machine-readable results to this path (skips PNG/report; for the UI bridge)")
+    args = ap.parse_args(argv)
+
+    basket = config.EQUITY_INDEX_FUTURES if args.basket == "futures" else config.EQUITY_INDEX_ETFS
+    if args.keys:
+        wanted = [k.strip().lower() for k in args.keys.split(",") if k.strip()]
+        basket = [s for s in basket if s.key in wanted]
+        if not basket:
+            print(f"[portfolio] ERROR: --keys {args.keys!r} matched no {args.basket} "
+                  "basket members.", file=sys.stderr)
+            return 2
+
+    if args.source == "csv":
+        resolution = "csv (as provided)"
+        print(f"[portfolio] loading CSVs from {args.csv_dir} for {[s.key for s in basket]}")
+        try:
+            frames = data.load_csv_all(args.csv_dir, symbols=basket)
+        except RuntimeError as e:
+            print(f"[portfolio] ERROR: {e}", file=sys.stderr)
+            return 2
+    elif args.source == "yahoo":
+        resolution = "1-day (Yahoo, adjusted)"
+        tickers = [s.yahoo_ticker for s in basket]
+        print(f"[portfolio] downloading from Yahoo {args.start}..{args.end}: {tickers}")
+        try:
+            frames = data.fetch_yahoo_all(symbols=basket, start=args.start, end=args.end)
+        except RuntimeError as e:
+            print(f"[portfolio] ERROR: {e}", file=sys.stderr)
+            return 2
+        if args.cache_csv:
+            data.save_frames_csv(frames, args.csv_dir)
+            print(f"[portfolio] cached Yahoo CSVs -> {args.csv_dir}")
+    else:
+        interval = "Minute" if args.intraday else "Day"
+        resolution = f"1-{interval.lower()}"
+        print(f"[portfolio] fetching {[s.key for s in basket]} {args.start}..{args.end} ({resolution})")
+        client = data.make_client()
+        try:
+            frames = data.fetch_all(client, symbols=basket, interval=interval, period=1,
+                                    start=args.start, end=args.end)
+        finally:
+            close = getattr(client, "close", None)
+            if callable(close):
+                close()
+
+    for k, df in frames.items():
+        lo = df.index.min().date() if len(df) else "-"
+        hi = df.index.max().date() if len(df) else "-"
+        print(f"[portfolio]   {k}: {len(df)} bars ({lo}..{hi}) via {df.attrs.get('exchange_id')}")
+
+    wide = data.align(frames)
+    if wide.empty:
+        print("[portfolio] ERROR: no overlapping data across the basket after alignment.", file=sys.stderr)
+        return 2
+    print(f"[portfolio] aligned rows: {len(wide)} ({wide.index.min().date()}..{wide.index.max().date()})")
+
+    # Sizing overrides. gross_target is per-name-clipped to |1.0|, so capital
+    # deployment also needs max_contracts (the $-per-|target|=1.0 lever). The cost
+    # model is sourced via config.cost_for(key) -> PORTFOLIO_BASE_COST at call
+    # time, so reassign that module default to propagate to every instrument.
+    import dataclasses
+    config.PORTFOLIO_BASE_COST = dataclasses.replace(
+        config.PORTFOLIO_BASE_COST, max_contracts=args.max_contracts)
+    cfg = dataclasses.replace(
+        config.DEFAULT,
+        portfolio=dataclasses.replace(config.DEFAULT.portfolio, gross_target=args.gross_target))
+    print(f"[portfolio] sizing: gross_target={cfg.portfolio.gross_target} "
+          f"max_contracts={config.PORTFOLIO_BASE_COST.max_contracts}")
+    closes = pf.closes_from_wide(wide, basket)
+
+    if len(wide) <= cfg.walk.warmup + cfg.walk.retune_days:
+        print(f"[portfolio] ERROR: only {len(wide)} bars; need > warmup ({cfg.walk.warmup}) "
+              f"+ retune ({cfg.walk.retune_days}). Provide more history.", file=sys.stderr)
+        return 2
+
+    print("[portfolio] walk-forward re-tuning (this is the slow rebuild)...")
+    wf = walkforward.run_walkforward(closes, cfg)
+    n_sw = int(wf.params_log["switched"].astype(bool).sum()) if len(wf.params_log) else 0
+    print(f"[portfolio] re-tunes: {len(wf.params_log)} ({n_sw} switched parameters)")
+
+    result = multi_backtest.backtest_portfolio(wf.targets, closes, cfg)
+    print(f"[portfolio] OOS stats: {result.stats}")
+
+    starting = cfg.costs.starting_cash
+    baseline_return_pct = float((result.baseline_equity.iloc[-1] - starting) / starting * 100.0)
+    print(f"[portfolio] equal-weight buy&hold return: {baseline_return_pct:.2f}%")
+
+    # Weekly-consistency lens — "how often does it actually win on a weekly basis?"
+    base_pnl = result.baseline_equity.diff().fillna(0.0)
+    strat_wk = multi_backtest.weekly_consistency(result.pnl, starting)
+    base_wk = multi_backtest.weekly_consistency(base_pnl, starting)
+    # Persist raw PnL so the weekly lens can be re-analysed without re-running the
+    # slow walk-forward.
+    try:
+        os.makedirs(args.out, exist_ok=True)
+        import pandas as _pd
+        _pd.DataFrame({"strategy": result.pnl, "buyhold": base_pnl}).to_csv(
+            os.path.join(args.out, "pnl.csv"))
+    except Exception:
+        pass
+    print("[portfolio] --- weekly consistency (strategy vs buy&hold) ---")
+    print(f"[portfolio]   active weeks:    {strat_wk['n_active_weeks']}/{strat_wk['n_weeks']}  vs  {base_wk['n_active_weeks']}/{base_wk['n_weeks']}")
+    print(f"[portfolio]   winning weeks:   {strat_wk['pct_winning_weeks']:.1f}%  vs  {base_wk['pct_winning_weeks']:.1f}%")
+    print(f"[portfolio]   avg week:        {strat_wk['avg_week_pct']:+.3f}%  vs  {base_wk['avg_week_pct']:+.3f}%")
+    print(f"[portfolio]   avg WIN week:    {strat_wk['avg_win_week_pct']:+.3f}%  vs  {base_wk['avg_win_week_pct']:+.3f}%")
+    print(f"[portfolio]   avg LOSS week:   {strat_wk['avg_loss_week_pct']:+.3f}%  vs  {base_wk['avg_loss_week_pct']:+.3f}%")
+    print(f"[portfolio]   win/loss ratio:  {strat_wk['win_loss_ratio']:.2f}    vs  {base_wk['win_loss_ratio']:.2f}")
+    print(f"[portfolio]   worst week:      {strat_wk['worst_week_pct']:+.3f}%  vs  {base_wk['worst_week_pct']:+.3f}%")
+    print(f"[portfolio]   longest losing streak: {strat_wk['max_losing_streak_weeks']}w  vs  {base_wk['max_losing_streak_weeks']}w")
+    print(f"[portfolio]   weekly Sharpe:   {strat_wk['weekly_sharpe']:.2f}    vs  {base_wk['weekly_sharpe']:.2f}")
+
+    data_summary = {
+        "symbols": ", ".join(f"{s.key.upper()}({frames[s.key].attrs.get('exchange_id')})" for s in basket),
+        "rows": len(wide),
+        "span": f"{wide.index.min().date()} → {wide.index.max().date()}",
+        "source": args.source,
+        "resolution": resolution,
+    }
+
+    # JSON path (for the JSDemo UI bridge): emit machine-readable results, no PNGs.
+    if args.json_path:
+        obj = result_json.to_result_dict(wf, result, cfg, data_summary, baseline_return_pct)
+        result_json.write_json(args.json_path, obj)
+        print(f"[portfolio] wrote JSON -> {args.json_path}")
+        return 0
+
+    out_dir = args.out
+    images = [
+        report.plot_portfolio_equity(result.equity, result.baseline_equity, out_dir),
+        report.plot_param_drift(wf.params_log, out_dir),
+        report.plot_holdings_heatmap(result.targets, out_dir),
+    ]
+    path = report.write_portfolio_report(
+        out_dir=out_dir, stats=result.stats, baseline_return_pct=baseline_return_pct,
+        params_log=wf.params_log, data_summary=data_summary, images=images,
+        cfg=cfg, resolution=resolution,
+    )
+    print(f"[portfolio] wrote report -> {path}")
+    print(f"[portfolio] artifacts in {out_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/Python/algo-py/research/run_study.py
+++ b/tools/Python/algo-py/research/run_study.py
@@ -1,0 +1,147 @@
+"""
+research/run_study.py
+
+Orchestrates the whole study:
+
+    fetch ES/CL/GC  →  align  →  combo model  →  backtest (full + event)  →  report
+
+Two data sources:
+
+    # CSV (default) — drop es.csv / cl.csv / gc.csv into research/data_csv/
+    python -m research.run_study
+    python -m research.run_study --csv-dir /path/to/csvs
+
+    # T4 sim (once the barchart 400 is sorted — see probe_data.py)
+    export T4_API_TOKEN=...
+    python -m research.run_study --source t4
+
+Outputs land in research/output/ (report.md + PNGs). --intraday requests Minute
+bars from T4 (no effect for CSV, which uses whatever the files contain).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+import pandas as pd
+
+from . import config, data, model as model_mod, report, result_json
+from .backtest import backtest
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="ES combo-signal war-window study")
+    ap.add_argument("--source", choices=["csv", "yahoo", "t4"], default="csv",
+                    help="data source (default: csv)")
+    ap.add_argument("--csv-dir", default=os.path.join(os.path.dirname(__file__), "data_csv"),
+                    help="directory holding es.csv / cl.csv / gc.csv (csv source)")
+    ap.add_argument("--cache-csv", action="store_true",
+                    help="yahoo only: also write the pulled data to --csv-dir for offline reruns")
+    ap.add_argument("--intraday", action="store_true", help="T4 only: request Minute bars instead of Day")
+    ap.add_argument("--out", default=os.path.join(os.path.dirname(__file__), "output"))
+    ap.add_argument("--json", dest="json_path", default=None,
+                    help="write the result as JSON to this path (for the PyDemo panel)")
+    args = ap.parse_args(argv)
+
+    if args.source == "csv":
+        resolution = "csv (as provided)"
+        print(f"[study] loading CSVs from {args.csv_dir}")
+        try:
+            frames = data.load_csv_all(args.csv_dir)
+        except RuntimeError as e:
+            print(f"[study] ERROR: {e}", file=sys.stderr)
+            return 2
+    elif args.source == "yahoo":
+        resolution = "1-day (Yahoo, adjusted)"
+        tickers = [s.yahoo_ticker for s in config.SYMBOLS]
+        print(f"[study] downloading from Yahoo {config.FETCH_START}..{config.FETCH_END}: {tickers}")
+        try:
+            frames = data.fetch_yahoo_all()
+        except RuntimeError as e:
+            print(f"[study] ERROR: {e}", file=sys.stderr)
+            return 2
+        if args.cache_csv:
+            data.save_frames_csv(frames, args.csv_dir)
+            print(f"[study] cached Yahoo CSVs -> {args.csv_dir}")
+    else:
+        interval = "Minute" if args.intraday else "Day"
+        period = 1
+        resolution = f"{period}-{interval.lower()}"
+        print(f"[study] fetching ES/CL/GC {config.FETCH_START}..{config.FETCH_END} ({resolution})")
+        client = data.make_client()
+        try:
+            frames = data.fetch_all(client, interval=interval, period=period)
+        finally:
+            client.close()
+
+    for k, df in frames.items():
+        print(f"[study]   {k}: {len(df)} bars "
+              f"({df.index.min().date() if len(df) else '-'}..{df.index.max().date() if len(df) else '-'}) "
+              f"via {df.attrs.get('exchange_id')}")
+
+    wide = data.align(frames)
+    if wide.empty:
+        print("[study] ERROR: no overlapping data across ES/CL/GC after alignment.", file=sys.stderr)
+        return 2
+    print(f"[study] aligned rows: {len(wide)} ({wide.index.min().date()}..{wide.index.max().date()})")
+
+    cfg = config.DEFAULT
+    out = model_mod.combine(wide, cfg)
+    calib_info = model_mod.calibrate(wide, cfg)
+    print(f"[study] calibration: {calib_info}")
+
+    # Full-span backtest.
+    full = backtest(out.frame["es_close"], out.target, cfg)
+    print(f"[study] full-span stats: {full.stats}")
+
+    # Event-window backtest (slice the target; re-run on the event prices).
+    ev_target = out.target.loc[config.EVENT_START:config.EVENT_END]
+    ev_prices = out.frame["es_close"].loc[config.EVENT_START:config.EVENT_END]
+    if len(ev_prices) < 2:
+        print("[study] WARNING: event window has <2 bars — zoom/stats will be thin.")
+        event_stats = {k: 0 for k in full.stats}
+    else:
+        event = backtest(ev_prices, ev_target, cfg)
+        event_stats = event.stats
+        print(f"[study] event-window stats: {event_stats}")
+
+    # JSON path (for the PyDemo Research hub): emit machine-readable results, no PNGs.
+    if args.json_path:
+        data_summary = {
+            "source": args.source, "resolution": resolution, "rows": len(wide),
+            "span": f"{wide.index.min().date()} → {wide.index.max().date()}",
+            "event_start": config.EVENT_START, "event_end": config.EVENT_END,
+        }
+        obj = result_json.to_war_dict(full, event_stats, calib_info=calib_info,
+                                      data_summary=data_summary)
+        result_json.write_json(args.json_path, obj)
+        print(f"[study] wrote JSON -> {args.json_path}")
+        return 0
+
+    # Report.
+    out_dir = args.out
+    images = [
+        report.plot_price_positions(out.frame.loc[config.CALIB_START:config.CALIB_END],
+                                     full.positions.loc[config.CALIB_START:config.CALIB_END], out_dir),
+        report.plot_equity(full, out_dir),
+        report.plot_war_zoom(out.frame, full.positions, out_dir),
+    ]
+    data_summary = {
+        "symbols": ", ".join(f"{s.key.upper()}({frames[s.key].attrs.get('exchange_id')})"
+                             for s in config.SYMBOLS),
+        "rows": len(wide),
+    }
+    path = report.write_report(
+        out_dir=out_dir, full_stats=full.stats, event_stats=event_stats,
+        calib_info=calib_info, data_summary=data_summary, images=images,
+        resolution=resolution,
+    )
+    print(f"[study] wrote report -> {path}")
+    print(f"[study] artifacts in {out_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/Python/algo-py/research/signals.py
+++ b/tools/Python/algo-py/research/signals.py
@@ -1,0 +1,71 @@
+"""
+research/signals.py
+
+Per-asset signal components for the slow-rebuild rotation study. Each function
+takes one instrument's close-price Series and returns a Series aligned to the
+input index — pure, no I/O, composing research/indicators.py.
+
+These are the RAW per-asset components. The cross-sectional combination (compare
+names against each other, rank, select) lives in research/portfolio.py, where
+the whole basket is in hand. Keeping them split means "how a name looks on its
+own" (here) is separate from "how it ranks vs its peers" (there).
+
+The four signals map to the user's request:
+  * skip-recent momentum  — trend, but excluding the freshest spike (anti-bubble)
+  * value / mean-reversion — cheap vs its own long-run mean
+  * overextension          — how stretched a name is (an explicit bubble guard)
+  * long-term trend gate   — only allow longs that are in an up-trend
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from . import config, indicators as ind
+
+
+def momentum_skip(close: pd.Series, lookback: int, skip: int) -> pd.Series:
+    """Return over `lookback` bars EXCLUDING the most recent `skip` bars.
+
+    The classic 12-1 momentum construction: measure the trend up to `skip` bars
+    ago, so the freshest (most bubble-prone) move is deliberately ignored.
+    With skip=0 this is a plain rate-of-change over `lookback`.
+    """
+    past = close.shift(skip)
+    base = close.shift(skip + lookback)
+    return past / base - 1.0
+
+
+def value_score(close: pd.Series, lookback: int) -> pd.Series:
+    """Mean-reversion / "value": negative z-score of price vs its trailing mean.
+    Positive (buy) when price is BELOW its ~1yr mean, negative when above."""
+    return -ind.zscore(close, lookback)
+
+
+def overextension(close: pd.Series, lookback: int) -> pd.Series:
+    """How stretched a name is: |z-score| of price vs its trailing mean. Large
+    values flag a name that has run far from its own mean (bubble guard). The
+    threshold/penalty is applied by the portfolio layer."""
+    return ind.zscore(close, lookback).abs()
+
+
+def trend_ok(close: pd.Series, lookback: int) -> pd.Series:
+    """Long-term trend gate: True where close is above its `lookback`-bar SMA.
+    NaN during warmup is treated as False (not yet allowed)."""
+    sma = ind.sma(close, lookback)
+    return (close > sma).where(sma.notna(), False)
+
+
+def asset_signals(close: pd.Series, p: config.SignalParams) -> pd.DataFrame:
+    """Bundle the four per-asset components into one DataFrame.
+
+    Columns: momentum, value, overext_z (raw |z|), trend_ok (bool). The
+    cross-sectional blend/rank happens in portfolio.py, which standardises
+    `momentum` and `value` across the basket before combining.
+    """
+    return pd.DataFrame({
+        "momentum": momentum_skip(close, p.mom_lookback, p.mom_skip),
+        "value": value_score(close, p.value_lookback),
+        "overext_z": overextension(close, p.value_lookback),
+        "trend_ok": trend_ok(close, p.trend_lookback),
+    })

--- a/tools/Python/algo-py/research/test_portfolio.py
+++ b/tools/Python/algo-py/research/test_portfolio.py
@@ -1,0 +1,157 @@
+"""
+research/test_portfolio.py
+
+Synthetic-data verification for the slow-rebuild rotation study — no market data
+or T4 needed. Run directly:
+
+    python -m research.test_portfolio
+
+Checks:
+  1. NO LOOK-AHEAD — perturbing FUTURE prices cannot change any earlier signal
+     score or walk-forward target.
+  2. RECONCILIATION — portfolio equity delta equals summed per-bar PnL.
+  3. TRADE THROTTLE — no rebalance changes more than max_trades_per_week names,
+     and sub-band tweaks are ignored.
+  4. GUARDS — the overextension and long-term-trend gates disqualify the names
+     they should.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import numpy as np
+import pandas as pd
+
+from . import config, multi_backtest, portfolio as pf, signals as sig, walkforward
+
+
+# Small, fast config so lookbacks fit a synthetic series.
+TEST_CFG = replace(
+    config.DEFAULT,
+    signals=replace(config.DEFAULT.signals, mom_lookback=10, mom_skip=2,
+                    value_lookback=20, trend_lookback=15, overext_z=2.0),
+    portfolio=replace(config.DEFAULT.portfolio, top_n=2, max_trades_per_week=2,
+                      no_trade_band=0.1),
+    walk=replace(config.DEFAULT.walk, warmup=30, trailing_window=40,
+                 rebalance_days=5, retune_days=5,
+                 grid_mom_lookback=(5, 10), grid_mom_skip=(0, 2),
+                 grid_value_lookback=(20,), grid_top_n=(1, 2)),
+)
+
+KEYS = ["a", "b", "c", "d"]
+
+
+def _make_closes(n: int = 160, seed: int = 7) -> dict[str, pd.Series]:
+    rng = np.random.default_rng(seed)
+    idx = pd.bdate_range("2022-01-03", periods=n)
+    out = {}
+    for i, k in enumerate(KEYS):
+        drift = 0.0004 * (i - 1)            # mix of up/down trends
+        steps = rng.normal(drift, 0.01, n)
+        out[k] = pd.Series(100.0 * np.exp(np.cumsum(steps)), index=idx)
+    return out
+
+
+def test_no_lookahead_scores() -> None:
+    closes = _make_closes()
+    p = TEST_CFG.signals
+    base = pf.composite_scores(closes, p)
+
+    n = len(base.index)
+    cut = int(0.7 * n)
+    perturbed = {k: v.copy() for k, v in closes.items()}
+    perturbed["a"].iloc[cut:] *= 1.8        # blow up the FUTURE
+    after = pf.composite_scores(perturbed, p)
+
+    a, b = base.iloc[:cut], after.iloc[:cut]
+    assert a.equals(b) or np.allclose(a.fillna(-999).values, b.fillna(-999).values), \
+        "look-ahead: future price change altered earlier composite scores"
+    print("  [1a] composite_scores is causal (no look-ahead) - OK")
+
+
+def test_no_lookahead_walkforward() -> None:
+    closes = _make_closes()
+    base = walkforward.run_walkforward(closes, TEST_CFG).targets
+
+    n = len(base.index)
+    cut = int(0.7 * n)
+    perturbed = {k: v.copy() for k, v in closes.items()}
+    perturbed["a"].iloc[cut:] *= 1.8
+    after = walkforward.run_walkforward(perturbed, TEST_CFG).targets
+
+    a, b = base.iloc[:cut], after.iloc[:cut]
+    assert np.allclose(a.values, b.values), \
+        "look-ahead: future price change altered earlier walk-forward targets"
+    print("  [1b] walk-forward targets are causal (no look-ahead) - OK")
+
+
+def test_reconciliation() -> None:
+    closes = _make_closes()
+    wf = walkforward.run_walkforward(closes, TEST_CFG)
+    res = multi_backtest.backtest_portfolio(wf.targets, closes, TEST_CFG)
+    start = TEST_CFG.costs.starting_cash
+    assert abs((res.equity.iloc[-1] - start) - res.pnl.sum()) < 1e-6, \
+        "portfolio equity does not reconcile with summed PnL"
+    print(f"  [2] equity reconciles (net ${res.pnl.sum():,.0f}, "
+          f"{res.stats['trades_per_week']:.2f} trades/wk) - OK")
+
+
+def test_trade_throttle() -> None:
+    cap = TEST_CFG.portfolio.max_trades_per_week
+    closes = _make_closes()
+    targets = walkforward.run_walkforward(closes, TEST_CFG).targets
+    changes = (targets.diff().abs() > 1e-9).sum(axis=1)
+    assert changes.max() <= cap, f"a rebalance changed {changes.max()} names (cap {cap})"
+
+    # Direct unit checks on the throttle.
+    keys = pd.Index(KEYS)
+    prev = pd.Series([0.0, 0.0, 0.0, 0.0], index=keys)
+    desired = pd.Series([0.25, 0.25, 0.25, 0.25], index=keys)  # 4 would-be changes
+    out = pf._throttle(prev, desired, TEST_CFG.portfolio)
+    assert int((out != prev).sum()) <= cap, "throttle exceeded the per-rebalance trade cap"
+
+    prev2 = pd.Series([0.5, 0.5, 0.0, 0.0], index=keys)
+    tweak = pd.Series([0.55, 0.5, 0.0, 0.0], index=keys)       # 0.05 < no_trade_band
+    out2 = pf._throttle(prev2, tweak, TEST_CFG.portfolio)
+    assert out2.equals(prev2), "throttle traded inside the no-trade band"
+    print(f"  [3] trade throttle holds (<={cap}/rebalance, no-trade band) - OK")
+
+
+def test_guards() -> None:
+    idx = pd.bdate_range("2022-01-03", periods=60)
+    # normal: gentle uptrend (eligible). overext: flat then a huge spike at the
+    # end (z ≫ overext_z). downtrend: monotone decline (below its SMA).
+    normal = pd.Series(100.0 * (1 + 0.002) ** np.arange(60), index=idx)
+    overext = pd.Series(100.0, index=idx).copy()
+    overext.iloc[-3:] = [180.0, 220.0, 260.0]
+    downtrend = pd.Series(100.0 * (1 - 0.01) ** np.arange(60), index=idx)
+    flat = pd.Series(100.0 + np.sin(np.arange(60) / 3.0), index=idx)
+
+    p = replace(TEST_CFG.signals, value_lookback=20, trend_lookback=15, overext_z=2.0)
+    scores = pf.composite_scores(
+        {"normal": normal, "overext": overext, "down": downtrend, "flat": flat}, p)
+    last = scores.iloc[-1]
+    assert pd.isna(last["overext"]), "overextension guard failed to drop the spiking name"
+    assert pd.isna(last["down"]), "trend gate failed to drop the down-trending name"
+    assert last[["normal", "flat"]].notna().any(), "guards disqualified every name"
+
+    # Sanity on the raw component.
+    assert sig.trend_ok(downtrend, 15).iloc[-1] == False  # noqa: E712
+    assert sig.overextension(overext, 20).iloc[-1] > 2.0
+    print("  [4] overextension + trend guards drop the right names - OK")
+
+
+def main() -> int:
+    print("[test_portfolio] synthetic verification")
+    test_no_lookahead_scores()
+    test_no_lookahead_walkforward()
+    test_reconciliation()
+    test_trade_throttle()
+    test_guards()
+    print("[test_portfolio] ALL CHECKS PASSED")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/Python/algo-py/research/walkforward.py
+++ b/tools/Python/algo-py/research/walkforward.py
@@ -1,0 +1,158 @@
+"""
+research/walkforward.py
+
+The "rebuild every week or so". Steps through time and, at each re-tune date,
+re-optimises the rotation's parameters using ONLY data up to that point, then
+applies them forward. This is the slow, anti-bubble core: the rule's shape is
+fixed (rank the basket, hold top-N), but its knobs (momentum lookback/skip,
+value lookback, how many names) are recalibrated on a trailing window and held
+steady unless a new set clearly beats the incumbent (hysteresis).
+
+No look-ahead by construction:
+  * the signal math (momentum/zscore/SMA, cross-sectional rank) is causal — a
+    row only ever sees past bars (this is asserted in test_portfolio.py);
+  * parameters for a segment are chosen from data strictly BEFORE that segment.
+
+Output: a stitched out-of-sample target matrix (dates x instruments) plus a log
+of the parameters chosen at each re-tune (for the param-drift plot).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from itertools import product
+from typing import Dict, List, Optional
+
+import numpy as np
+import pandas as pd
+
+from . import config, portfolio as pf
+
+
+@dataclass
+class WalkForwardResult:
+    targets: pd.DataFrame      # OOS target matrix (dates x instrument keys)
+    params_log: pd.DataFrame   # one row per re-tune: chosen params + objective
+    closes: pd.DataFrame       # aligned close matrix (for the backtest stage)
+
+
+# --- candidate parameter sets ------------------------------------------------
+def _candidates(cfg: config.StudyConfig):
+    """Cartesian product of the coarse grid (kept small → fast & robust)."""
+    w = cfg.walk
+    for ml, ms, vl, tn in product(w.grid_mom_lookback, w.grid_mom_skip,
+                                  w.grid_value_lookback, w.grid_top_n):
+        if ms + ml <= 0:
+            continue
+        yield {"mom_lookback": ml, "mom_skip": ms, "value_lookback": vl, "top_n": tn}
+
+
+def _signal_params(cfg: config.StudyConfig, cand: dict) -> config.SignalParams:
+    return replace(cfg.signals, mom_lookback=cand["mom_lookback"],
+                   mom_skip=cand["mom_skip"], value_lookback=cand["value_lookback"])
+
+
+def _port_params(cfg: config.StudyConfig, cand: dict) -> config.PortfolioParams:
+    return replace(cfg.portfolio, top_n=cand["top_n"])
+
+
+# --- objective ---------------------------------------------------------------
+def _objective(scores: pd.DataFrame, price_mat: pd.DataFrame,
+               pp: config.PortfolioParams, cfg: config.StudyConfig) -> float:
+    """Scale-free trailing-window objective for parameter selection: annualised
+    Sharpe of the (1-bar-lagged) portfolio return minus a turnover penalty.
+
+    Takes a precomputed `scores` frame so the caller can reuse it across top_n
+    variants (top_n only affects selection, not scoring). Deliberately uses
+    simple per-bar returns (not the dollar cost model) — we're ranking parameter
+    sets, not reporting PnL, so scale-free is right and the turnover penalty
+    pushes toward stable, lower-churn settings.
+    """
+    w = cfg.walk
+    rb = pf.rebalance_dates(scores.index, w.rebalance_days, start_at=0)
+    targets = pf.select_targets(scores, pp, rb)
+
+    rets = (targets.shift(1) * price_mat.pct_change()).sum(axis=1)
+    rets = rets.tail(w.trailing_window).replace([np.inf, -np.inf], np.nan).dropna()
+    if len(rets) < 5 or rets.std(ddof=0) == 0:
+        return float("-inf")
+    sharpe = float(np.sqrt(252.0) * rets.mean() / rets.std(ddof=0))
+
+    turn = targets.diff().abs().sum(axis=1).tail(w.trailing_window)
+    turnover = float(turn[turn > 0].mean()) if (turn > 0).any() else 0.0
+    return sharpe - w.turnover_penalty * turnover
+
+
+# --- main loop ---------------------------------------------------------------
+def run_walkforward(closes: Dict[str, pd.Series], cfg: config.StudyConfig = config.DEFAULT) -> WalkForwardResult:
+    keys = list(closes.keys())
+    price_mat = pd.DataFrame({k: closes[k] for k in keys})
+    index = price_mat.index
+    w = cfg.walk
+
+    targets = pd.DataFrame(0.0, index=index, columns=keys)
+    retune_set = set(pf.rebalance_dates(index, w.retune_days, start_at=w.warmup))
+    rebalance_set = set(pf.rebalance_dates(index, w.rebalance_days, start_at=w.warmup))
+
+    incumbent: Optional[dict] = None      # current parameter set
+    incumbent_scores: Optional[pd.DataFrame] = None  # composite scores for it
+    incumbent_pp: Optional[config.PortfolioParams] = None
+    prev = pd.Series(0.0, index=keys)
+    log: List[dict] = []
+
+    # How much trailing history each tune needs: enough indicator warmup for the
+    # widest grid lookback, plus the trailing_window we actually score over.
+    warm_need = max(max(w.grid_value_lookback),
+                    max(w.grid_mom_lookback) + max(w.grid_mom_skip),
+                    cfg.signals.trend_lookback)
+    tune_tail = warm_need + w.trailing_window + 5
+
+    for ts in index:
+        if ts in retune_set:
+            # Tune on a bounded trailing slice ending at `ts` (still strictly
+            # causal — only past data — just bounded so cost doesn't grow).
+            past_mat = price_mat.loc[:ts].tail(tune_tail)
+            past = {k: past_mat[k] for k in keys}
+
+            # Cache composite_scores by signal key — top_n variants share scores.
+            score_cache: dict = {}
+
+            def _scores_for(cand: dict):
+                key = (cand["mom_lookback"], cand["mom_skip"], cand["value_lookback"])
+                sc = score_cache.get(key)
+                if sc is None:
+                    sc = pf.composite_scores(past, _signal_params(cfg, cand))
+                    score_cache[key] = sc
+                return sc
+
+            best, best_obj = None, float("-inf")
+            for cand in _candidates(cfg):
+                obj = _objective(_scores_for(cand), past_mat, _port_params(cfg, cand), cfg)
+                if obj > best_obj:
+                    best, best_obj = cand, obj
+
+            # Hysteresis: only switch if the new set beats the incumbent's score
+            # on THIS trailing window by an absolute margin (slow rebuild). The
+            # incumbent's scores are already in the cache (it came from the grid).
+            switched = False
+            if incumbent is None:
+                incumbent, switched = best, True
+            elif best is not None:
+                inc_obj = _objective(_scores_for(incumbent), past_mat,
+                                     _port_params(cfg, incumbent), cfg)
+                if best_obj - inc_obj > w.hysteresis:
+                    incumbent, switched = best, True
+
+            if switched and incumbent is not None:
+                incumbent_scores = pf.composite_scores(closes, _signal_params(cfg, incumbent))
+                incumbent_pp = _port_params(cfg, incumbent)
+            log.append({"ts": ts, **(incumbent or {}), "objective": best_obj, "switched": switched})
+
+        if ts in rebalance_set and incumbent_scores is not None:
+            desired = pf._desired_row(incumbent_scores.loc[ts], incumbent_pp)
+            prev = pf._throttle(prev, desired, incumbent_pp)
+
+        targets.loc[ts] = prev.values
+
+    params_log = pd.DataFrame(log).set_index("ts") if log else pd.DataFrame()
+    return WalkForwardResult(targets=targets, params_log=params_log, closes=price_mat)


### PR DESCRIPTION
## Summary

Adds three on-demand trading tools to **PyDemo**, plus the research package they build on. Each opens from a new button on the connection bar — nothing is launched at startup.

- **`chart/`** — companion lightweight-charts window (candles, volume, live ticks, history paging/scroll-back, order & position overlays, indicators, drawings). Opens via a new **Chart** button instead of at app startup, so there's no webview cost unless requested.
- **`backtest/`** — self-contained, JSDemo-parity backtester (indicators, sim broker with OCO brackets, core strategies). Runs on the chart's loaded bars or a fetched date range.
- **`study/`** — walk-forward portfolio-rotation results viewer; shells out to the `algo-py` research CLI (degrades gracefully with a dialog if `algo-py`/matplotlib are absent).
- **`algo-py/`** — the research package (walk-forward rotation study) the viewer reuses.

The only changes to pre-existing files are the necessary wiring: `T4APIClient.py` (retain `config`), `main.py` (defer chart launch), `t4_gui.py` (tool buttons + handlers), and `config.template.yaml` / `requirements.txt` / `.gitignore`. Everything else is new folders.

## Decoder dependency

The chart decodes T4 binary bars via `t4login`, provided by the in-repo **`t4-Python-api`** package (already on `main`). Install references were repointed there (from the older local `t4-pythonConversion-api`, which is intentionally not included). The two copies had diverged; `t4-Python-api` is the correct one (e.g. it fixes a swapped round-up/round-down in `price.py`).

## Excluded (runtime/generated)

Study outputs (`research/output*/`), market CSVs (`research/data_csv/*.csv`), chart drawings (`config/chart_drawings.json`), and `__pycache__`/`*.pyc` are gitignored. JSDemo changes are intentionally out of scope (a later PR).

## Verification

- Headless: `python -m py_compile` clean; PyDemo test suite (79 tests) green.
- Recommended before merge: `pip install -e tools/Python/t4-Python-api` and re-run the chart tests + a live chart open, to confirm parity against `main`'s decoder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)