### PR TITLE
JSDemo: OCO order builder

### DIFF
--- a/tools/JavaScript/JSDemo/T4APIClient.js
+++ b/tools/JavaScript/JSDemo/T4APIClient.js
@@ -28,6 +28,7 @@ class T4APIClient {
         this.loginResponse = null;
         this.accounts = new Map();
         this.selectedAccount = null;
+        this.subscribedAccounts = new Set(); // accounts with an active AccountSubscribe
 
         // JWT token management
         this.jwtToken = null;
@@ -84,6 +85,10 @@ class T4APIClient {
         // ack/reject handlers can correlate the server response to the rows that
         // were sent. Populated by submitBatch, cleared on ack/reject.
         this.pendingBatches = new Map();
+
+        // Resolvers awaiting the next AccountSubscribeResponse, so a subscribe issued
+        // before a batch can be confirmed before the orders are sent.
+        this._subscribeWaiters = [];
 
         // Connection retry
         this.reconnectAttempts = 0;
@@ -172,6 +177,7 @@ class T4APIClient {
                     uplMode: 0
                 }
             });
+            this.subscribedAccounts.delete(this.selectedAccount);
         }
 
         this.selectedAccount = accountId;
@@ -185,8 +191,39 @@ class T4APIClient {
                     uplMode: 1
                 }
             });
+            this.subscribedAccounts.add(accountId);
             this.log(`Subscribed to account: ${accountId}`, 'info');
         }
+    }
+
+    // Subscribe to any accounts not already subscribed, in a single AccountSubscribe.
+    // Used before a multi-account batch so the server doesn't reject "not subscribed".
+    async ensureAccountsSubscribed(accountIds) {
+        if (this.config.autoSubscribeAccounts) return; // all accounts already subscribed
+        const missing = [...new Set(accountIds)]
+            .filter(Boolean)
+            .filter(id => !this.subscribedAccounts.has(id));
+        if (missing.length === 0) return;
+
+        const ack = this._awaitNextSubscribeResponse(); // resolve on server ack
+        await this.sendMessage({
+            accountSubscribe: {
+                subscribe: 2,               // ACCOUNT_SUBSCRIBE_TYPE_ALL_UPDATES
+                subscribeAllAccounts: false,
+                accountId: missing,
+                uplMode: 1                  // UPL_MODE_AVERAGE
+            }
+        });
+        missing.forEach(id => this.subscribedAccounts.add(id));
+        this.log(`Subscribed to accounts for batch: ${missing.join(', ')}`, 'info');
+        await ack; // ensure the server has registered the subscription before we submit
+    }
+
+    _awaitNextSubscribeResponse(timeoutMs = 3000) {
+        return new Promise(resolve => {
+            this._subscribeWaiters.push(resolve);
+            setTimeout(() => resolve(null), timeoutMs); // fall through on message-order guarantee
+        });
     }
 
     async subscribeMarket(exchangeId, contractId, marketId) {
@@ -505,6 +542,12 @@ class T4APIClient {
             }
         });
 
+        // Every account referenced by the batch must be subscribed or the server
+        // rejects the whole batch ("Account … is not subscribed"). In per-account
+        // mode only the selected account is subscribed, so subscribe the rest first.
+        const accts = rows.map(r => r.accountId || this.selectedAccount);
+        await this.ensureAccountsSubscribed(accts);
+
         // Always send a client batch_id so the ack/reject (which echoes it) can be
         // correlated back to these rows. Kept simple and unique per session.
         const id = batchId || `b-${Date.now()}-${this.pendingBatches.size}`;
@@ -514,6 +557,79 @@ class T4APIClient {
 
         this.log(`Batch submitted: ${submissions.length} order(s), batchId ${id}`, 'info');
         return id;
+    }
+
+    // Submit a true OCO (One-Cancels-Other): two or more independent, simultaneously
+    // working orders linked by ORDER_LINK_OCO. Whichever fills first cancels the rest.
+    // Unlike the AUTO_OCO brackets in submitOrder(), each leg carries its own real
+    // volume and is live immediately (no ACTIVATION_TYPE_HOLD / parent entry).
+    //
+    // legs: array of { side, priceType, price, volume }
+    //   side:      'buy'|'sell' or 1/-1
+    //   priceType: 'limit'|'market'|'stop'
+    //   price:     absolute price (ignored for market legs)
+    //   volume:    per-leg quantity
+    async submitOcoOrder(legs) {
+        if (!this.selectedAccount || !this.currentMarketId) {
+            throw new Error('No account or market selected');
+        }
+        if (!Array.isArray(legs) || legs.length < 2) {
+            throw new Error('OCO requires at least two legs');
+        }
+
+        const orders = legs.map(leg => {
+            // Convert string price type to enum value (same mapping as submitOrder).
+            const ptLower = (typeof leg.priceType === 'string' ? leg.priceType : 'limit').toLowerCase();
+            const priceTypeValue = ptLower === 'market'
+                ? T4Proto.t4proto.v1.common.PriceType.PRICE_TYPE_MARKET       // 0
+                : ptLower === 'stop'
+                    ? T4Proto.t4proto.v1.common.PriceType.PRICE_TYPE_STOP_MARKET  // 5
+                    : T4Proto.t4proto.v1.common.PriceType.PRICE_TYPE_LIMIT;       // 1
+
+            // Convert buy/sell string or number to enum value (same as submitOrder).
+            const buySellValue = typeof leg.side === 'string'
+                ? (leg.side.toLowerCase() === 'buy'
+                    ? T4Proto.t4proto.v1.common.BuySell.BUY_SELL_BUY    // 1
+                    : T4Proto.t4proto.v1.common.BuySell.BUY_SELL_SELL)  // -1
+                : (leg.side === 1
+                    ? T4Proto.t4proto.v1.common.BuySell.BUY_SELL_BUY
+                    : T4Proto.t4proto.v1.common.BuySell.BUY_SELL_SELL);
+
+            return {
+                buySell: buySellValue,
+                priceType: priceTypeValue,
+                timeType: T4Proto.t4proto.v1.common.TimeType.TIME_TYPE_NORMAL, // 0
+                volume: leg.volume,
+                // Limit/stop price set only when the order type requires it.
+                limitPrice: priceTypeValue === T4Proto.t4proto.v1.common.PriceType.PRICE_TYPE_LIMIT
+                    ? { value: leg.price.toString() }
+                    : null,
+                stopPrice: priceTypeValue === T4Proto.t4proto.v1.common.PriceType.PRICE_TYPE_STOP_MARKET
+                    ? { value: leg.price.toString() }
+                    : null,
+                // No activationType: both legs are live working orders immediately.
+            };
+        });
+
+        const orderSubmit = {
+            orderSubmit: {
+                accountId: this.selectedAccount,
+                marketId: this.currentMarketId,
+                orderLink: T4Proto.t4proto.v1.common.OrderLink.ORDER_LINK_OCO, // 1
+                manualOrderIndicator: true,
+                orders: orders
+            }
+        };
+
+        await this.sendMessage(orderSubmit);
+
+        this.log(`OCO order submitted: ${legs.length} legs (one-cancels-other)`, 'info');
+        legs.forEach((leg, i) => {
+            const sideText = orders[i].buySell === T4Proto.t4proto.v1.common.BuySell.BUY_SELL_BUY ? 'Buy' : 'Sell';
+            const ptLower = (typeof leg.priceType === 'string' ? leg.priceType : 'limit').toLowerCase();
+            const priceText = ptLower === 'market' ? 'Market' : leg.price;
+            this.log(`  Leg ${i + 1}: ${sideText} ${leg.volume} @ ${priceText} (${ptLower})`, 'info');
+        });
     }
 
     async pullOrder(orderId) {
@@ -863,8 +979,11 @@ async reviseOrder(orderId, volume, price, priceType = 'limit') {
         if (response.success) {
             this.log('Account subscribe: Success', 'info');
         } else {
-            this.log(`Account subscribe failed: ${response.errors.join(', ')}`, 'error');
+            this.log(`Account subscribe failed: ${(response.errors || []).join(', ')}`, 'error');
         }
+        const waiters = this._subscribeWaiters;
+        this._subscribeWaiters = [];
+        waiters.forEach(w => w(response));
     }
 
     handleAccountDetails(details) {

--- a/tools/JavaScript/JSDemo/chart.css
+++ b/tools/JavaScript/JSDemo/chart.css
@@ -350,6 +350,26 @@
     margin-left: 4px;
 }
 
+/* Chart order-type selector — matches the .order-btn look. */
+.chart-section .order-type-select {
+    background: #2a2a2a;
+    color: #d0d0d0;
+    border: 1px solid #444;
+    border-radius: 3px;
+    padding: 3px 6px;
+    cursor: pointer;
+    font-size: 12px;
+}
+
+.chart-section .order-type-select:hover {
+    border-color: #666;
+}
+
+.chart-section .order-type-select:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
 /* While the drag-to-place tool is armed, use a crosshair so users know the
    chart is in "place an order" mode rather than its normal pan mode. */
 .chart-section .chart-container.chart-drag-armed,

--- a/tools/JavaScript/JSDemo/chart/features/DragOrder.js
+++ b/tools/JavaScript/JSDemo/chart/features/DragOrder.js
@@ -70,6 +70,7 @@
 
             this._toolMode = null;       // null | 'buy' | 'sell'
             this._bracketMode = false;
+            this._orderType = 'auto';    // 'auto' | 'limit' | 'stop' | 'market' | 'oco'
             this._onToolChange = null;
             this._onStateChange = null;
             this._dragging = false;
@@ -84,6 +85,11 @@
             //     tStart, tEnd, tpLine, slLine, entryLine, tpFill, slFill,
             //     tpBadge, slBadge, confirmBar }
             this._setup = null;
+            // OCO setup state. Null when not building an OCO. Two independent,
+            // simultaneously-working legs (one cancels the other):
+            //   { side, leg1, leg2, qty, decimals, leg1Line, leg2Line,
+            //     confirmBar, anchor }
+            this._oco = null;
             this._edgeDrag = null;       // null | 'tp' | 'sl'
             this._edgeStartY = NaN;      // grab anchor for sensitivity scaling
             this._edgeStartPrice = NaN;
@@ -118,6 +124,7 @@
             // contract with different tick size / decimals.
             this._unsubSymbol = ctx.bus.on('symbol:changed', () => {
                 this._exitSetup(true);
+                this._exitOco(true);
                 this.cancelTool();
             });
         }
@@ -144,12 +151,24 @@
             // they can still Submit/Cancel the current bracket.
         }
 
+        // Force the order type for chart-placed entries. 'auto' keeps the
+        // drop-vs-last inference (_inferType); 'limit'/'stop'/'market' force it;
+        // 'oco' makes a drop open the two-line OCO builder.
+        setOrderType(type) {
+            const t = (typeof type === 'string' ? type : 'auto').toLowerCase();
+            this._orderType = ['auto', 'limit', 'stop', 'market', 'oco'].includes(t) ? t : 'auto';
+            // Leaving OCO mode with a build open: tear it down so a stale
+            // overlay doesn't linger.
+            if (this._orderType !== 'oco') this._exitOco(true);
+        }
+
         // ---------- arm / disarm -----------------------------------------
         beginTool(mode) {
             if (mode !== 'buy' && mode !== 'sell') return;
             if (this._toolMode === mode) return;
             // Switching mode mid-flight: clean current drag + setup first.
             this._exitSetup(true);
+            this._exitOco(true);
             this._endDrag(true);
             this._toolMode = mode;
             this._armChart();
@@ -159,6 +178,7 @@
         cancelTool() {
             if (!this._toolMode) return;
             this._exitSetup(true);
+            this._exitOco(true);
             this._endDrag(true);
             this._disarmChart();
             this._toolMode = null;
@@ -174,7 +194,7 @@
 
         _emitStateChange() {
             if (this._onStateChange) {
-                const state = this._setup ? 'setup' : (this._toolMode ? 'armed' : 'idle');
+                const state = (this._setup || this._oco) ? 'setup' : (this._toolMode ? 'armed' : 'idle');
                 try { this._onStateChange(state); }
                 catch (err) { console.error('[DragOrder] onStateChange failed:', err); }
             }
@@ -233,10 +253,27 @@
                 e.preventDefault();
                 e.stopPropagation();
                 if (this._setup) this._exitSetup(true);
+                else if (this._oco) this._exitOco(true);
                 else this.cancelTool();
                 return;
             }
             if (e.button !== 0) return;
+
+            // In OCO setup: only leg-line grabs are allowed, same as bracket setup.
+            if (this._oco) {
+                const rect = this._container.getBoundingClientRect();
+                const y = e.clientY - rect.top;
+                const edge = this._hitTestEdge(y);
+                if (!edge) return;
+                e.preventDefault();
+                e.stopPropagation();
+                this._edgeDrag = edge;              // 'leg1' | 'leg2'
+                this._edgeStartY = y;
+                this._edgeStartPrice = (edge === 'leg1') ? this._oco.leg1 : this._oco.leg2;
+                this._activePointerId = e.pointerId;
+                try { this._container.setPointerCapture(e.pointerId); } catch (_) { /* ignore */ }
+                return;
+            }
 
             // In setup mode: only edge grabs are allowed. Other clicks are
             // ignored so the user can't accidentally start a new entry drag
@@ -281,7 +318,7 @@
                 return;
             }
             // Hover feedback over an edge while in setup: ns-resize cursor.
-            if (this._setup && !this._dragging) {
+            if ((this._setup || this._oco) && !this._dragging) {
                 const rect = this._container.getBoundingClientRect();
                 const y = e.clientY - rect.top;
                 const edge = this._hitTestEdge(y);
@@ -317,7 +354,9 @@
             if (e.type === 'pointercancel') return;
             if (!Number.isFinite(price)) return;
 
-            if (this._bracketMode) {
+            if (this._orderType === 'oco') {
+                this._enterOcoSetup(price, anchor);
+            } else if (this._bracketMode) {
                 this._enterSetup(price, anchor);
             } else {
                 this._fireOrder(price, anchor);
@@ -335,6 +374,10 @@
             }
             if (this._setup) {
                 this._exitSetup(true);
+                return;
+            }
+            if (this._oco) {
+                this._exitOco(true);
                 return;
             }
             if (this._dragging) {
@@ -387,11 +430,15 @@
         _updatePreview(price) {
             if (!this._series) return;
             const side = this._toolMode === 'buy' ? 1 : -1;
-            const type = this._inferType(side, price);
+            const type = this._effectiveType(side, price);
             const color = side === 1 ? '#26a69a' : '#ef5350';
             const decimals = this._host?.knownDecimals ?? 2;
             const sideText = side === 1 ? 'BUY' : 'SELL';
-            const title = `${sideText} ${type.toUpperCase()} @ ${Number(price).toFixed(decimals)}`;
+            // Market has no working price — label it as such but still track the
+            // cursor line so the gesture has visual feedback.
+            const title = type === 'market'
+                ? `${sideText} MARKET`
+                : `${sideText} ${type.toUpperCase()} @ ${Number(price).toFixed(decimals)}`;
 
             const LS = global.LightweightCharts?.LineStyle;
             const dashed = LS?.Dashed ?? 2;
@@ -422,6 +469,16 @@
             return price >= last ? 'limit' : 'stop';
         }
 
+        // Effective type for a simple drag entry: honour a forced Type from the
+        // toolbar (limit/stop/market), else fall back to drop-vs-last inference.
+        // 'oco' never reaches here (it opens the OCO builder instead).
+        _effectiveType(side, price) {
+            if (this._orderType === 'limit' || this._orderType === 'stop' || this._orderType === 'market') {
+                return this._orderType;
+            }
+            return this._inferType(side, price);
+        }
+
         _lastPrice() {
             const id = this._host?.activeMarketId;
             if (!id || !this._client?.getMarketSnapshot) return NaN;
@@ -446,13 +503,17 @@
         _fireOrder(price, anchor) {
             if (typeof this.onOrder !== 'function') return;
             const side = this._toolMode === 'buy' ? 1 : -1;
-            const priceType = this._inferType(side, price);
+            const priceType = this._effectiveType(side, price);
             const volume = this._readQty();
             const decimals = this._host?.knownDecimals ?? 2;
             const sideText = side === 1 ? 'BUY' : 'SELL';
-            const label = `${sideText} ${priceType.toUpperCase()} @ ${Number(price).toFixed(decimals)}`;
+            // Market ignores the drop price (submitOrder sends no limit/stop price).
+            const orderPrice = priceType === 'market' ? null : price;
+            const label = priceType === 'market'
+                ? `${sideText} MARKET`
+                : `${sideText} ${priceType.toUpperCase()} @ ${Number(price).toFixed(decimals)}`;
             try {
-                this.onOrder({ side, priceType, price, volume, anchor, label });
+                this.onOrder({ side, priceType, price: orderPrice, volume, anchor, label });
             } catch (err) {
                 console.error('[DragOrder] onOrder failed:', err);
             }
@@ -785,8 +846,18 @@
 
         // ---------- edge drag --------------------------------------------
         _hitTestEdge(yPx) {
+            if (!this._series) return null;
+            // OCO build: two independent leg lines.
+            if (this._oco) {
+                const y1 = this._series.priceToCoordinate(this._oco.leg1);
+                const y2 = this._series.priceToCoordinate(this._oco.leg2);
+                const d1 = y1 != null ? Math.abs(y1 - yPx) : Infinity;
+                const d2 = y2 != null ? Math.abs(y2 - yPx) : Infinity;
+                if (Math.min(d1, d2) > EDGE_HIT_PX) return null;
+                return d1 <= d2 ? 'leg1' : 'leg2';
+            }
             const s = this._setup;
-            if (!s || !this._series) return null;
+            if (!s) return null;
             const yTp = this._series.priceToCoordinate(s.tp);
             const ySl = this._series.priceToCoordinate(s.sl);
             const dTp = yTp != null ? Math.abs(yTp - yPx) : Infinity;
@@ -797,6 +868,12 @@
         }
 
         _updateEdge(which, rawPrice) {
+            // OCO leg lines move freely (no entry-relative clamping); each just
+            // snaps to tick and relabels with its side + inferred type.
+            if (this._oco) {
+                this._updateOcoLeg(which, rawPrice);
+                return;
+            }
             const s = this._setup;
             if (!s) return;
             const tick = this._tickSize();
@@ -897,6 +974,158 @@
             } catch (err) {
                 console.error('[DragOrder] bracket onOrder failed:', err);
             }
+        }
+
+        // ================================================================
+        // OCO setup mode (two independent, simultaneously-working legs)
+        // ================================================================
+
+        _enterOcoSetup(dropPrice, anchor) {
+            if (!this._series || !this._chart) return;
+            if (this._oco) this._exitOco(true);
+            const side = this._toolMode === 'buy' ? 1 : -1;
+            const qty = this._readQty();
+            const decimals = this._host?.knownDecimals ?? 2;
+            const tick = this._tickSize();
+            const offset = Number.isFinite(tick) && tick > 0
+                ? tick * DEFAULT_OFFSET_TICKS
+                : dropPrice * 0.0005;
+
+            // Leg 1 at the drop; leg 2 a few ticks below it so both lines are
+            // visible and grabbable right away. Each is freely draggable after.
+            this._oco = {
+                side, leg1: dropPrice, leg2: dropPrice - offset, qty, decimals,
+                anchor, leg1Line: null, leg2Line: null, confirmBar: null, labelEl: null
+            };
+            this._renderOco();
+            this._emitStateChange();
+        }
+
+        _renderOco() {
+            const o = this._oco;
+            if (!o || !this._series || !this._chart) return;
+            const LS = global.LightweightCharts?.LineStyle;
+            const solid = LS?.Solid ?? 0;
+            const color = o.side === 1 ? '#26a69a' : '#ef5350';
+
+            o.leg1Line = this._series.createPriceLine({
+                price: o.leg1, color, lineWidth: 2, lineStyle: solid,
+                axisLabelVisible: true, title: this._ocoLegLabel(o.leg1)
+            });
+            o.leg2Line = this._series.createPriceLine({
+                price: o.leg2, color, lineWidth: 2, lineStyle: solid,
+                axisLabelVisible: true, title: this._ocoLegLabel(o.leg2)
+            });
+
+            o.confirmBar = this._mkOcoConfirmBar();
+            this._container.appendChild(o.confirmBar);
+        }
+
+        _ocoLegLabel(price) {
+            const o = this._oco;
+            const sideText = o.side === 1 ? 'BUY' : 'SELL';
+            const type = this._inferType(o.side, price).toUpperCase();
+            return `${sideText} ${type} @ ${this._fmt(price)}`;
+        }
+
+        _ocoConfirmText() {
+            const o = this._oco;
+            const sideText = o.side === 1 ? 'BUY' : 'SELL';
+            const t1 = this._inferType(o.side, o.leg1).toUpperCase();
+            const t2 = this._inferType(o.side, o.leg2).toUpperCase();
+            return `OCO ${sideText} × ${o.qty}:  ${t1} @ ${this._fmt(o.leg1)}  /  ${t2} @ ${this._fmt(o.leg2)}`;
+        }
+
+        _updateOcoConfirmText() {
+            if (this._oco?.labelEl) this._oco.labelEl.textContent = this._ocoConfirmText();
+        }
+
+        _mkOcoConfirmBar() {
+            const o = this._oco;
+            const sideCls = o.side === 1 ? 'cbc-buy' : 'cbc-sell';
+
+            const bar = document.createElement('div');
+            bar.className = 'chart-bracket-confirm';
+
+            const label = document.createElement('span');
+            label.className = 'cbc-label';
+            label.textContent = this._ocoConfirmText();
+            o.labelEl = label;
+
+            const submit = document.createElement('button');
+            submit.type = 'button';
+            submit.className = `cbc-btn cbc-submit ${sideCls}`;
+            submit.textContent = 'Submit OCO';
+            submit.addEventListener('click', (e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                this._submitOco();
+            });
+
+            const cancel = document.createElement('button');
+            cancel.type = 'button';
+            cancel.className = 'cbc-btn cbc-cancel';
+            cancel.textContent = 'Cancel';
+            cancel.addEventListener('click', (e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                this._exitOco(true);
+            });
+
+            bar.appendChild(label);
+            bar.appendChild(submit);
+            bar.appendChild(cancel);
+            // Keep pointerdown on the bar from reaching the chart drag handler.
+            bar.addEventListener('pointerdown', (e) => e.stopPropagation(), true);
+            return bar;
+        }
+
+        _updateOcoLeg(which, rawPrice) {
+            const o = this._oco;
+            if (!o) return;
+            // rawPrice is already tick-snapped by _edgePriceFromEvent.
+            if (which === 'leg1') {
+                o.leg1 = rawPrice;
+                o.leg1Line?.applyOptions({ price: rawPrice, title: this._ocoLegLabel(rawPrice) });
+            } else {
+                o.leg2 = rawPrice;
+                o.leg2Line?.applyOptions({ price: rawPrice, title: this._ocoLegLabel(rawPrice) });
+            }
+            this._updateOcoConfirmText();
+        }
+
+        _submitOco() {
+            const o = this._oco;
+            if (!o) return;
+            if (typeof this.onOrder !== 'function') { this._exitOco(true); return; }
+            const legs = [o.leg1, o.leg2].map(p => ({
+                side: o.side,
+                priceType: this._inferType(o.side, p),
+                price: p,
+                volume: o.qty
+            }));
+            const label = this._ocoConfirmText();
+            const anchor = o.anchor;
+            // Tear down BEFORE firing so a handler that hits the API doesn't race
+            // the next pointer event into a half-cleaned setup (mirrors bracket).
+            this._exitOco(false);
+            try {
+                this.onOrder({ isOco: true, legs, anchor, label });
+            } catch (err) {
+                console.error('[DragOrder] OCO onOrder failed:', err);
+            }
+        }
+
+        _exitOco(/* canceled */) {
+            if (!this._oco) return;
+            const o = this._oco;
+            if (o.leg1Line && this._series) { try { this._series.removePriceLine(o.leg1Line); } catch (_) { /* gone */ } }
+            if (o.leg2Line && this._series) { try { this._series.removePriceLine(o.leg2Line); } catch (_) { /* gone */ } }
+            if (o.confirmBar?.parentNode) o.confirmBar.parentNode.removeChild(o.confirmBar);
+            this._container?.classList.remove('chart-bracket-edge-hover');
+            this._oco = null;
+            this._edgeDrag = null;
+            this._emitStateChange();
         }
 
         // ---------- math helpers -----------------------------------------

--- a/tools/JavaScript/JSDemo/chart/ui/OrderToolbar.js
+++ b/tools/JavaScript/JSDemo/chart/ui/OrderToolbar.js
@@ -45,6 +45,36 @@
             this._btnSell = mkBtn('Sell Order', 'order-btn-sell',
                 () => this._toggle('sell'));
 
+            // Type selector: 'auto' keeps the drop-vs-last inference; limit/stop/
+            // market force the type for the simple drag entry; 'oco' turns a drop
+            // into a two-line OCO builder. Market/OCO are incompatible with the
+            // Bracket flow, so Bracket is disabled while either is selected.
+            this._typeSelect = document.createElement('select');
+            this._typeSelect.className = 'order-type-select';
+            this._typeSelect.title = 'Order type for chart-placed orders';
+            [
+                ['auto', 'Auto'], ['limit', 'Limit'], ['stop', 'Stop'],
+                ['market', 'Market'], ['oco', 'OCO']
+            ].forEach(([value, text]) => {
+                const opt = document.createElement('option');
+                opt.value = value;
+                opt.textContent = text;
+                this._typeSelect.appendChild(opt);
+            });
+            this._typeSelect.addEventListener('change', () => {
+                const type = this._typeSelect.value;
+                this._feature.setOrderType(type);
+                const incompatible = type === 'market' || type === 'oco';
+                if (this._bracketChk) {
+                    this._bracketChk.disabled = incompatible;
+                    if (incompatible && this._bracketChk.checked) {
+                        this._bracketChk.checked = false;
+                        this._feature.setBracketMode(false);
+                    }
+                }
+                this._updateHint();
+            });
+
             // Bracket toggle: when on, entry drop opens the TP/SL setup
             // overlay instead of submitting an immediate order.
             const bracketWrap = document.createElement('label');
@@ -66,6 +96,7 @@
 
             root.appendChild(this._btnBuy);
             root.appendChild(this._btnSell);
+            root.appendChild(this._typeSelect);
             root.appendChild(bracketWrap);
             root.appendChild(this._hint);
             this.host.appendChild(root);
@@ -95,8 +126,19 @@
                 this._hint.textContent = '';
                 return;
             }
+            const type = this._typeSelect?.value || 'auto';
             if (this._state === 'setup') {
-                this._hint.textContent = 'Adjust TP/SL, then Submit (Esc cancels)';
+                this._hint.textContent = type === 'oco'
+                    ? 'Drag the two OCO lines, then Submit OCO (Esc cancels)'
+                    : 'Adjust TP/SL, then Submit (Esc cancels)';
+                return;
+            }
+            if (type === 'oco') {
+                this._hint.textContent = 'Drag on chart to place two OCO lines (Esc to cancel)';
+                return;
+            }
+            if (type === 'market') {
+                this._hint.textContent = 'Click chart to place at Market (Esc to cancel)';
                 return;
             }
             this._hint.textContent = this._bracketChk?.checked

--- a/tools/JavaScript/JSDemo/index.html
+++ b/tools/JavaScript/JSDemo/index.html
@@ -119,6 +119,7 @@
                 <select id="orderType">
                     <option value="limit">Limit</option>
                     <option value="market">Market</option>
+                    <option value="oco">OCO</option>
                 </select>
             </div>
             <div class="form-group">
@@ -157,6 +158,42 @@
                     <label for="trailingStopToggle">Trailing</label>
                 </div>
             </div>
+            <!-- OCO builder: two independent, simultaneously-working legs (one cancels the other).
+                 Shown only when Type = OCO; the standard single-order fields above are hidden. -->
+            <div id="ocoGroup" style="display: none;">
+                <div class="form-group oco-leg" data-leg="1">
+                    <label>Leg 1:</label>
+                    <div class="oco-leg-fields">
+                        <select id="ocoLeg1Side">
+                            <option value="1">Buy</option>
+                            <option value="-1">Sell</option>
+                        </select>
+                        <select id="ocoLeg1Type">
+                            <option value="limit">Limit</option>
+                            <option value="market">Market</option>
+                            <option value="stop">Stop</option>
+                        </select>
+                        <input type="number" id="ocoLeg1Volume" value="1" min="1" placeholder="Vol">
+                        <input type="number" id="ocoLeg1Price" step="0.01" value="100" placeholder="Price">
+                    </div>
+                </div>
+                <div class="form-group oco-leg" data-leg="2">
+                    <label>Leg 2:</label>
+                    <div class="oco-leg-fields">
+                        <select id="ocoLeg2Side">
+                            <option value="1">Buy</option>
+                            <option value="-1">Sell</option>
+                        </select>
+                        <select id="ocoLeg2Type">
+                            <option value="limit">Limit</option>
+                            <option value="market">Market</option>
+                            <option value="stop">Stop</option>
+                        </select>
+                        <input type="number" id="ocoLeg2Volume" value="1" min="1" placeholder="Vol">
+                        <input type="number" id="ocoLeg2Price" step="0.01" value="100" placeholder="Price">
+                    </div>
+                </div>
+            </div>
             <div class="form-group submit-btn-container">
                 <button id="submitOrderBtn" class="submit-order-btn">Submit Order</button>
             </div>
@@ -167,9 +204,11 @@
     <div class="section">
         <h2>Batch Orders</h2>
         <p class="batch-hint">
-            Stage flat entry orders from the form above (Side / Type / Volume / Price),
-            then edit Side / Type / Vol / Price directly in the table before submitting
-            them as one <strong>atomic</strong> batch — if any order fails validation,
+            Stage orders from the form above (Side / Type / Volume / Price); set a
+            Take Profit / Stop Loss there first to stage an <strong>AOCO bracket</strong>
+            (parent + offspring) row. Edit Side / Type / Vol / Price directly in the
+            table (brackets are read-only — remove and re-stage to change them), then
+            submit as one <strong>atomic</strong> batch — if any order fails validation,
             none are sent. Switch account and/or contract between adds to build a
             multi-account batch.
         </p>
@@ -187,6 +226,7 @@
                         <th>Type</th>
                         <th>Vol</th>
                         <th>Price</th>
+                        <th>Bracket</th>
                         <th></th>
                     </tr>
                 </thead>
@@ -222,7 +262,7 @@
     </div>
 
     <!-- Orders -->
-    <div class="section">
+    <div class="section full-width">
         <h2>Orders</h2>
         <div class="table-container">
             <table id="ordersTable">
@@ -386,6 +426,16 @@
             orderSide: document.getElementById('orderSide'),
             orderVolume: document.getElementById('orderVolume'),
             orderPrice: document.getElementById('orderPrice'),
+            // OCO builder
+            ocoGroup: document.getElementById('ocoGroup'),
+            ocoLeg1Side: document.getElementById('ocoLeg1Side'),
+            ocoLeg1Type: document.getElementById('ocoLeg1Type'),
+            ocoLeg1Volume: document.getElementById('ocoLeg1Volume'),
+            ocoLeg1Price: document.getElementById('ocoLeg1Price'),
+            ocoLeg2Side: document.getElementById('ocoLeg2Side'),
+            ocoLeg2Type: document.getElementById('ocoLeg2Type'),
+            ocoLeg2Volume: document.getElementById('ocoLeg2Volume'),
+            ocoLeg2Price: document.getElementById('ocoLeg2Price'),
             submitOrderBtn: document.getElementById('submitOrderBtn'),
             addToBatchBtn: document.getElementById('addToBatchBtn'),
             submitBatchBtn: document.getElementById('submitBatchBtn'),
@@ -595,9 +645,21 @@
                 // call stay consistent with the right-click context menu.
                 if (window.ChartFeatures?.DragOrder) {
                     const dragOrder = new window.ChartFeatures.DragOrder();
-                    dragOrder.onOrder = ({ side, priceType, price, volume, anchor, label, takeProfitPrice, stopLossPrice, isBracket }) => {
+                    dragOrder.onOrder = (intent) => {
+                        const { side, priceType, price, volume, anchor, label,
+                                takeProfitPrice, stopLossPrice, isBracket, isOco, legs } = intent;
                         if (!client.selectedAccount) {
                             log('Select an account before trading from the chart', 'error');
+                            return;
+                        }
+                        // OCO: two independent legs; the setup + Submit bar is the
+                        // confirmation step, so fire directly (like the bracket flow).
+                        if (isOco) {
+                            client.submitOcoOrder(legs);
+                            const summary = legs
+                                .map(l => `${l.side === 1 ? 'BUY' : 'SELL'} ${l.volume} ${l.priceType} @ ${l.price}`)
+                                .join(' / ');
+                            log(`Chart OCO: ${summary}`, 'info');
                             return;
                         }
                         const qty = Math.max(1, parseInt(volume, 10) || 1);
@@ -1196,6 +1258,23 @@
             }
         }
 
+        // Order type toggle: when OCO is chosen, hide the standard single-order
+        // fields (they don't apply) and reveal the two-leg OCO builder; restore
+        // them for Limit/Market.
+        const standardOrderGroups = [
+            elements.orderSide.closest('.form-group'),
+            elements.orderVolume.closest('.form-group'),
+            document.getElementById('priceGroup'),
+            document.querySelector('.bracket-mode-group'),
+            document.getElementById('takeProfitPrice').closest('.form-group'),
+            document.getElementById('stopLossPrice').closest('.form-group'),
+        ];
+        elements.orderType.addEventListener('change', () => {
+            const isOco = elements.orderType.value === 'oco';
+            standardOrderGroups.forEach(g => { if (g) g.style.display = isOco ? 'none' : ''; });
+            elements.ocoGroup.style.display = isOco ? '' : 'none';
+        });
+
         // Bracket mode toggle handler
         document.querySelectorAll('input[name="bracketMode"]').forEach(radio => {
             radio.addEventListener('change', (e) => {
@@ -1229,6 +1308,18 @@
 
         async function submitOrder() {
             try {
+                // OCO mode: build two independent legs and submit as one-cancels-other.
+                if (elements.orderType.value === 'oco') {
+                    const buildLeg = (n) => ({
+                        side: parseInt(elements[`ocoLeg${n}Side`].value),
+                        priceType: elements[`ocoLeg${n}Type`].value,
+                        volume: parseInt(elements[`ocoLeg${n}Volume`].value),
+                        price: parseFloat(elements[`ocoLeg${n}Price`].value),
+                    });
+                    await client.submitOcoOrder([buildLeg(1), buildLeg(2)]);
+                    return;
+                }
+
                 const side = parseInt(elements.orderSide.value);
                 const volume = parseInt(elements.orderVolume.value);
                 const priceType = elements.orderType.value; // 'limit' or 'market'
@@ -1323,6 +1414,10 @@
                 price.disabled = isMarket;
                 tr.appendChild(controlCell(price));
 
+                // Read-only bracket badge (edit by removing + re-staging from the form).
+                const summary = bracketSummary(row);
+                tr.appendChild(textCell(summary, summary === '—' ? null : summary));
+
                 const removeCell = document.createElement('td');
                 const removeBtn = document.createElement('button');
                 removeBtn.className = 'batch-remove-btn';
@@ -1340,6 +1435,19 @@
         }
 
         // --- renderBatch cell helpers ---
+        // One-line summary of a row's AOCO bracket for the read-only Bracket column.
+        // Returns '—' for flat rows (no TP/SL). Mode tag: '$' = dollar-distance
+        // (AUTO_OCO), 'price' = absolute price (AUTO_OCO_P).
+        function bracketSummary(row) {
+            const hasTp = row.takeProfitDollars != null;
+            const hasSl = row.stopLossDollars != null;
+            if (!hasTp && !hasSl) return '—';
+            const parts = [];
+            if (hasTp) parts.push(`TP ${row.takeProfitDollars}`);
+            if (hasSl) parts.push(`SL ${row.stopLossDollars}${row.trailingStop ? ' (trail)' : ''}`);
+            const mode = row.bracketMode === 'price' ? 'price' : '$';
+            return `${parts.join(' / ')} · ${mode}`;
+        }
         function textCell(text, title) {
             const td = document.createElement('td');
             td.textContent = text;
@@ -1398,14 +1506,32 @@
                 elements.orderPrice.value = price; // reflect the staged price for visibility
             }
 
+            // Carry the single-order bracket controls onto the row so it stages as an
+            // AOCO parent+offspring group (same inputs submitOrder reads). Bracket
+            // fields are only attached when a TP/SL is set, keeping flat rows clean.
+            const bracketMode = document.querySelector('input[name="bracketMode"]:checked').value;
+            const tpEl = document.getElementById('takeProfitPrice');
+            const slEl = document.getElementById('stopLossPrice');
+            const trailEl = document.getElementById('trailingStopToggle');
+            const takeProfitDollars = tpEl && tpEl.value ? parseFloat(tpEl.value) : null;
+            const stopLossDollars   = slEl && slEl.value ? parseFloat(slEl.value) : null;
+            const trailingStop      = trailEl ? trailEl.checked : false;
+
             batchRows.push({
                 accountId: client.selectedAccount,
                 marketId: client.currentMarketId,
-                side, volume, price, priceType
+                side, volume, price, priceType,
+                ...(takeProfitDollars !== null ? { takeProfitDollars } : {}),
+                ...(stopLossDollars   !== null ? { stopLossDollars }   : {}),
+                ...(takeProfitDollars !== null || stopLossDollars !== null
+                    ? { trailingStop, bracketMode } : {}),
             });
             renderBatch();
             const stagedPriceText = priceType === 'market' ? 'Market' : price;
-            log(`Batch: staged ${side === 1 ? 'Buy' : 'Sell'} ${volume} @ ${stagedPriceText} on ${client.currentMarketId} (${batchRows.length} staged)`, 'info');
+            const bracketText = (takeProfitDollars !== null || stopLossDollars !== null)
+                ? ` | ${bracketSummary(batchRows[batchRows.length - 1])}`
+                : '';
+            log(`Batch: staged ${side === 1 ? 'Buy' : 'Sell'} ${volume} @ ${stagedPriceText} on ${client.currentMarketId}${bracketText} (${batchRows.length} staged)`, 'info');
         }
 
         function clearBatch() {

--- a/tools/JavaScript/JSDemo/styles.css
+++ b/tools/JavaScript/JSDemo/styles.css
@@ -705,6 +705,22 @@ th {
         cursor: pointer;
     }
 
+/* ---------- OCO builder (two-leg one-cancels-other) ------------------ */
+#ocoGroup {
+    grid-column: 1 / -1; /* span the full 2-column .order-form grid */
+}
+
+.oco-leg-fields {
+    display: flex;
+    gap: 8px;
+}
+
+    .oco-leg-fields select,
+    .oco-leg-fields input {
+        flex: 1;
+        min-width: 0;
+    }
+
 /* ---------- Trade History blotter ------------------------------------ */
 .th-session-badge {
     font-size: 11px;


### PR DESCRIPTION
## Summary

Adds an OCO (one-cancels-other) order builder to JSDemo and tightens up the
batch-ordering flow, with supporting chart/UI improvements. JS-only — all changes
are under `tools/JavaScript/JSDemo/`.

### Changes
- **OCO order builder** — drag-to-place OCO orders on the chart (`DragOrder.js`),
  toolbar controls (`OrderToolbar.js`), and client wiring in `T4APIClient.js`.
- **Batch ordering fixes** — corrections to the batch submission path in `T4APIClient.js`.
- **UI improvements** — order builder markup in `index.html`, styling in
  `chart.css` and `styles.css`.

### Files (6)
- `T4APIClient.js`, `chart/features/DragOrder.js`, `chart/ui/OrderToolbar.js`
- `index.html`, `chart.css`, `styles.css`

🤖 Generated with [Claude Code](https://claude.com/claude-code)