### PR TITLE
Aoco order fix

### DIFF
--- a/tools/JavaScript/JSDemo/T4APIClient.js
+++ b/tools/JavaScript/JSDemo/T4APIClient.js
@@ -461,12 +461,12 @@ class T4APIClient {
         this.log(`Order submitted: ${sideText} ${volume} @ ${priceText} (Type: ${priceType}, Bracket: ${bracketMode})`, 'info');
 
         if (takeProfitDollars !== null) {
-            const tpLabel = bracketMode === 'price' ? `Price ${takeProfitDollars}` : `Distance ${takeProfitDollars}`;
+            const tpLabel = bracketMode === 'price' ? `Price ${takeProfitDollars}` : `Dollar Distance ${takeProfitDollars}`;
             this.log(`Take profit: ${tpLabel} (${protectionSide === T4Proto.t4proto.v1.common.BuySell.BUY_SELL_BUY ? 'Buy' : 'Sell'})`, 'info');
         }
 
         if (stopLossDollars !== null) {
-            const slLabel = bracketMode === 'price' ? `Price ${stopLossDollars}` : `Distance ${stopLossDollars}`;
+            const slLabel = bracketMode === 'price' ? `Price ${stopLossDollars}` : `Dollar Distance ${stopLossDollars}`;
             this.log(`Stop loss: ${slLabel}${trailingStop ? ' (Trailing)' : ''} (${protectionSide === T4Proto.t4proto.v1.common.BuySell.BUY_SELL_BUY ? 'Buy' : 'Sell'})`, 'info');
         }
 

--- a/tools/JavaScript/JSDemo/T4APIClient.js
+++ b/tools/JavaScript/JSDemo/T4APIClient.js
@@ -315,18 +315,9 @@ class T4APIClient {
         // Determine if we need OCO order linking
         const hasBracketOrders = takeProfitDollars !== null || stopLossDollars !== null;
 
-        // We know the entry price for a limit or stop entry, so we can express the
-        // bracket as absolute child prices — held orders then show the real price
-        // instead of a raw offset. Market entries have no price until fill, so they
-        // keep AUTO_OCO offset semantics (offset shows only until the immediate fill).
-        const entryPriceKnown =
-            (priceTypeValue === T4Proto.t4proto.v1.common.PriceType.PRICE_TYPE_LIMIT
-             || priceTypeValue === T4Proto.t4proto.v1.common.PriceType.PRICE_TYPE_STOP_MARKET)
-            && Number.isFinite(Number(price));
-
-        // Child prices are absolute when the user typed absolute prices ('price' mode)
-        // or when we can derive them from a known entry (offset mode + known entry).
-        const useAbsoluteBracket = bracketMode === 'price' || entryPriceKnown;
+        // Dollars mode sends raw offsets (AUTO_OCO); Price mode sends absolute child
+        // prices (AUTO_OCO_P). Keeps the "$" bracket a true AOCO order in all cases.
+        const useAbsoluteBracket = bracketMode === 'price';
 
         // AUTO_OCO_P carries absolute child prices; AUTO_OCO carries raw offsets.
         const orderLinkValue = hasBracketOrders
@@ -362,17 +353,6 @@ class T4APIClient {
             ? marketDetails.decimals
             : marketDetails.realDecimals;
 
-        // tickSize is the minimum price increment (e.g. ES = 0.25). Used only to
-        // snap the offset-mode bracket distance onto a tradable price grid.
-        const tickSize = Number(marketDetails.minPriceIncrement?.value);
-
-        // Snap a price offset to the nearest valid tick so the bracket lands on a
-        // tradable price. No-op when tick size is unknown.
-        const snapToTick = (offset) =>
-            (Number.isFinite(tickSize) && tickSize > 0)
-                ? Math.round(offset / tickSize) * tickSize
-                : offset;
-
         // Add take profit order if specified
         if (takeProfitDollars !== null) {
 
@@ -382,28 +362,20 @@ class T4APIClient {
                 // AOCO_P mode: user provides absolute price directly
                 takeProfitLimitPrice = takeProfitDollars; // In price mode, the value IS the absolute price
             } else {
-                // Offset mode: the entered value is a price distance off the entry
-                // (e.g. 100 = 100 price units away). Buy: TP above (+); Sell: TP below (−).
-                let off = snapToTick(Math.abs(takeProfitDollars));
-                off = (buySellValue === T4Proto.t4proto.v1.common.BuySell.BUY_SELL_BUY) ? off : -off;
-
-                // Known entry -> absolute price (held order shows the real price via
-                // AUTO_OCO_P). Market entry -> raw offset (AUTO_OCO applies it at fill).
-                takeProfitLimitPrice = entryPriceKnown
-                    ? snapToTick(Number(price) + off)
-                    : off;
+                // Offset mode: the entered value IS a price distance off the fill.
+                // AUTO_OCO applies it at fill. Buy: TP above (+); Sell: TP below (−).
+                const dist = Math.abs(takeProfitDollars);
+                takeProfitLimitPrice = (buySellValue === T4Proto.t4proto.v1.common.BuySell.BUY_SELL_BUY) ? dist : -dist;
             }
 
-            if (takeProfitLimitPrice !== null) {
-                orders.push({
-                    buySell: protectionSide,
-                    priceType: T4Proto.t4proto.v1.common.PriceType.PRICE_TYPE_LIMIT,
-                    timeType: T4Proto.t4proto.v1.common.TimeType.TIME_TYPE_GOOD_TILL_CANCELLED,
-                    volume: 0,
-                    limitPrice: { value: takeProfitLimitPrice.toString() },
-                    activationType: T4Proto.t4proto.v1.common.ActivationType.ACTIVATION_TYPE_HOLD
-                });
-            }
+            orders.push({
+                buySell: protectionSide,
+                priceType: T4Proto.t4proto.v1.common.PriceType.PRICE_TYPE_LIMIT,
+                timeType: T4Proto.t4proto.v1.common.TimeType.TIME_TYPE_GOOD_TILL_CANCELLED,
+                volume: 0,
+                limitPrice: { value: takeProfitLimitPrice.toString() },
+                activationType: T4Proto.t4proto.v1.common.ActivationType.ACTIVATION_TYPE_HOLD
+            });
         }
 
         // Add stop loss order if specified
@@ -415,20 +387,15 @@ class T4APIClient {
                 // AOCO_P mode: user provides absolute price directly
                 stopLossStopPrice = stopLossDollars; // In price mode, the value IS the absolute price
             } else {
-                // Offset mode: price distance off the entry. Buy: SL below (−); Sell: SL above (+).
-                let off = snapToTick(Math.abs(stopLossDollars));
-                off = (buySellValue === T4Proto.t4proto.v1.common.BuySell.BUY_SELL_BUY) ? -off : off;
-
-                // Known entry -> absolute price (held order shows the real price via
-                // AUTO_OCO_P). Market entry -> raw offset (AUTO_OCO applies it at fill).
-                stopLossStopPrice = entryPriceKnown
-                    ? snapToTick(Number(price) + off)
-                    : off;
+                // Offset mode: the entered value IS a price distance off the fill.
+                // Buy: SL below (−); Sell: SL above (+).
+                const dist = Math.abs(stopLossDollars);
+                stopLossStopPrice = (buySellValue === T4Proto.t4proto.v1.common.BuySell.BUY_SELL_BUY) ? -dist : dist;
             }
 
             if (trailingStop) {
-                const trailDistance = useAbsoluteBracket
-                    ? Math.abs(Number(price) - stopLossStopPrice).toFixed(priceDecimals)
+                const trailDistance = bracketMode === 'price'
+                    ? Math.abs(price - stopLossStopPrice).toFixed(priceDecimals)
                     : Math.abs(stopLossStopPrice).toFixed(priceDecimals);
 
                 orders.push({
@@ -494,12 +461,12 @@ class T4APIClient {
         this.log(`Order submitted: ${sideText} ${volume} @ ${priceText} (Type: ${priceType}, Bracket: ${bracketMode})`, 'info');
 
         if (takeProfitDollars !== null) {
-            const tpLabel = bracketMode === 'price' ? `Price ${takeProfitDollars}` : `$${takeProfitDollars}`;
+            const tpLabel = bracketMode === 'price' ? `Price ${takeProfitDollars}` : `Distance ${takeProfitDollars}`;
             this.log(`Take profit: ${tpLabel} (${protectionSide === T4Proto.t4proto.v1.common.BuySell.BUY_SELL_BUY ? 'Buy' : 'Sell'})`, 'info');
         }
 
         if (stopLossDollars !== null) {
-            const slLabel = bracketMode === 'price' ? `Price ${stopLossDollars}` : `$${stopLossDollars}`;
+            const slLabel = bracketMode === 'price' ? `Price ${stopLossDollars}` : `Distance ${stopLossDollars}`;
             this.log(`Stop loss: ${slLabel}${trailingStop ? ' (Trailing)' : ''} (${protectionSide === T4Proto.t4proto.v1.common.BuySell.BUY_SELL_BUY ? 'Buy' : 'Sell'})`, 'info');
         }
 

--- a/tools/JavaScript/JSDemo/T4APIClient.js
+++ b/tools/JavaScript/JSDemo/T4APIClient.js
@@ -362,10 +362,11 @@ class T4APIClient {
                 // AOCO_P mode: user provides absolute price directly
                 takeProfitLimitPrice = takeProfitDollars; // In price mode, the value IS the absolute price
             } else {
-                // Offset mode: the entered value IS a price distance off the fill.
-                // AUTO_OCO applies it at fill. Buy: TP above (+); Sell: TP below (−).
-                const dist = Math.abs(takeProfitDollars);
-                takeProfitLimitPrice = (buySellValue === T4Proto.t4proto.v1.common.BuySell.BUY_SELL_BUY) ? dist : -dist;
+                // Dollars mode: convert the $ P&L into a price offset off the fill —
+                // (|$|/volume)/pointValue/(10**decimals) — then sign per side.
+                // AUTO_OCO applies the offset at fill. Buy: TP above (+); Sell: TP below (−).
+                let tpOffset = (Math.abs(takeProfitDollars / volume) / marketDetails.pointValue.value) / (10 ** priceDecimals);
+                takeProfitLimitPrice = (buySellValue === T4Proto.t4proto.v1.common.BuySell.BUY_SELL_BUY) ? tpOffset : -tpOffset;
             }
 
             orders.push({
@@ -387,10 +388,11 @@ class T4APIClient {
                 // AOCO_P mode: user provides absolute price directly
                 stopLossStopPrice = stopLossDollars; // In price mode, the value IS the absolute price
             } else {
-                // Offset mode: the entered value IS a price distance off the fill.
+                // Dollars mode: convert the $ P&L into a price offset off the fill —
+                // (|$|/volume)/pointValue/(10**decimals) — then sign per side.
                 // Buy: SL below (−); Sell: SL above (+).
-                const dist = Math.abs(stopLossDollars);
-                stopLossStopPrice = (buySellValue === T4Proto.t4proto.v1.common.BuySell.BUY_SELL_BUY) ? -dist : dist;
+                let slOffset = (Math.abs(stopLossDollars / volume) / marketDetails.pointValue.value) / (10 ** priceDecimals);
+                stopLossStopPrice = (buySellValue === T4Proto.t4proto.v1.common.BuySell.BUY_SELL_BUY) ? -slOffset : slOffset;
             }
 
             if (trailingStop) {
@@ -461,12 +463,12 @@ class T4APIClient {
         this.log(`Order submitted: ${sideText} ${volume} @ ${priceText} (Type: ${priceType}, Bracket: ${bracketMode})`, 'info');
 
         if (takeProfitDollars !== null) {
-            const tpLabel = bracketMode === 'price' ? `Price ${takeProfitDollars}` : `Dollar Distance ${takeProfitDollars}`;
+            const tpLabel = bracketMode === 'price' ? `Price ${takeProfitDollars}` : `$${takeProfitDollars}`;
             this.log(`Take profit: ${tpLabel} (${protectionSide === T4Proto.t4proto.v1.common.BuySell.BUY_SELL_BUY ? 'Buy' : 'Sell'})`, 'info');
         }
 
         if (stopLossDollars !== null) {
-            const slLabel = bracketMode === 'price' ? `Price ${stopLossDollars}` : `Dollar Distance ${stopLossDollars}`;
+            const slLabel = bracketMode === 'price' ? `Price ${stopLossDollars}` : `$${stopLossDollars}`;
             this.log(`Stop loss: ${slLabel}${trailingStop ? ' (Trailing)' : ''} (${protectionSide === T4Proto.t4proto.v1.common.BuySell.BUY_SELL_BUY ? 'Buy' : 'Sell'})`, 'info');
         }
 

--- a/tools/JavaScript/JSDemo/index.html
+++ b/tools/JavaScript/JSDemo/index.html
@@ -141,18 +141,18 @@
                 <label>Bracket Mode:</label>
                 <div class="bracket-toggle">
                     <input type="radio" name="bracketMode" id="bracketModeDollars" value="dollars" checked>
-                    <label for="bracketModeDollars">Dollars ($)</label>
+                    <label for="bracketModeDollars">Distance</label>
                     <input type="radio" name="bracketMode" id="bracketModePrice" value="price">
                     <label for="bracketModePrice">Price (AOCO_P)</label>
                 </div>
             </div>
             <div class="form-group">
-                <label for="takeProfitPrice" id="takeProfitLabel">Take Profit ($):</label>
-                <input type="number" id="takeProfitPrice" step="1" placeholder="Optional">
+                <label for="takeProfitPrice" id="takeProfitLabel">Take Profit (Distance):</label>
+                <input type="number" id="takeProfitPrice" step="0.01" placeholder="Optional">
             </div>
             <div class="form-group">
-                <label for="stopLossPrice" id="stopLossLabel">Stop Loss ($):</label>
-                <input type="number" id="stopLossPrice" step="1" placeholder="Optional">
+                <label for="stopLossPrice" id="stopLossLabel">Stop Loss (Distance):</label>
+                <input type="number" id="stopLossPrice" step="0.01" placeholder="Optional">
                 <div class="trailing-toggle">
                     <input type="checkbox" id="trailingStopToggle">
                     <label for="trailingStopToggle">Trailing</label>
@@ -1293,12 +1293,12 @@
                 const slInput = document.getElementById('stopLossPrice');
 
                 if (mode === 'dollars') {
-                    tpLabel.textContent = 'Take Profit ($):';
-                    slLabel.textContent = 'Stop Loss ($):';
-                    tpInput.step = '1';
-                    slInput.step = '1';
-                    tpInput.placeholder = 'Optional';
-                    slInput.placeholder = 'Optional';
+                    tpLabel.textContent = 'Take Profit (Distance):';
+                    slLabel.textContent = 'Stop Loss (Distance):';
+                    tpInput.step = '0.01';
+                    slInput.step = '0.01';
+                    tpInput.placeholder = 'Price distance';
+                    slInput.placeholder = 'Price distance';
                 } else {
                     tpLabel.textContent = 'Take Profit (Price):';
                     slLabel.textContent = 'Stop Loss (Price):';
@@ -1494,7 +1494,7 @@
             const parts = [];
             if (hasTp) parts.push(`TP ${row.takeProfitDollars}`);
             if (hasSl) parts.push(`SL ${row.stopLossDollars}${row.trailingStop ? ' (trail)' : ''}`);
-            const mode = row.bracketMode === 'price' ? 'price' : '$';
+            const mode = row.bracketMode === 'price' ? 'price' : 'dist';
             return `${parts.join(' / ')} · ${mode}`;
         }
         // One-line summary of a staged true-OCO row (independent legs, one-cancels-other)

--- a/tools/JavaScript/JSDemo/index.html
+++ b/tools/JavaScript/JSDemo/index.html
@@ -141,20 +141,18 @@
                 <label>Bracket Mode:</label>
                 <div class="bracket-toggle">
                     <input type="radio" name="bracketMode" id="bracketModeDollars" value="dollars" checked>
-                    <label for="bracketModeDollars">Distance</label>
-                    <input type="radio" name="bracketMode" id="bracketModeCalc" value="calculated">
-                    <label for="bracketModeCalc">Calculated Distance</label>
+                    <label for="bracketModeDollars">Dollars ($)</label>
                     <input type="radio" name="bracketMode" id="bracketModePrice" value="price">
                     <label for="bracketModePrice">Price (AOCO_P)</label>
                 </div>
             </div>
             <div class="form-group">
-                <label for="takeProfitPrice" id="takeProfitLabel">Take Profit (Distance in Dollars):</label>
-                <input type="number" id="takeProfitPrice" step="0.01" placeholder="Dollar distance">
+                <label for="takeProfitPrice" id="takeProfitLabel">Take Profit ($):</label>
+                <input type="number" id="takeProfitPrice" step="1" placeholder="Optional">
             </div>
             <div class="form-group">
-                <label for="stopLossPrice" id="stopLossLabel">Stop Loss (Distance in Dollars):</label>
-                <input type="number" id="stopLossPrice" step="0.01" placeholder="Dollar distance">
+                <label for="stopLossPrice" id="stopLossLabel">Stop Loss ($):</label>
+                <input type="number" id="stopLossPrice" step="1" placeholder="Optional">
                 <div class="trailing-toggle">
                     <input type="checkbox" id="trailingStopToggle">
                     <label for="trailingStopToggle">Trailing</label>
@@ -1295,39 +1293,26 @@
                 const slInput = document.getElementById('stopLossPrice');
 
                 if (mode === 'dollars') {
-                    tpLabel.textContent = 'Take Profit (Distance in Dollars):';
-                    slLabel.textContent = 'Stop Loss (Distance in Dollars):';
-                    tpInput.placeholder = 'Dollar distance';
-                    slInput.placeholder = 'Dollar distance';
-                } else if (mode === 'calculated') {
-                    tpLabel.textContent = 'Take Profit (Calculated Distance):';
-                    slLabel.textContent = 'Stop Loss (Calculated Distance):';
-                    tpInput.placeholder = 'Dollar P&L → price offset';
-                    slInput.placeholder = 'Dollar P&L → price offset';
+                    tpLabel.textContent = 'Take Profit ($):';
+                    slLabel.textContent = 'Stop Loss ($):';
+                    tpInput.step = '1';
+                    slInput.step = '1';
+                    tpInput.placeholder = 'Optional';
+                    slInput.placeholder = 'Optional';
                 } else {
                     tpLabel.textContent = 'Take Profit (Price):';
                     slLabel.textContent = 'Stop Loss (Price):';
+                    tpInput.step = '0.01';
+                    slInput.step = '0.01';
                     tpInput.placeholder = 'Absolute price';
                     slInput.placeholder = 'Absolute price';
                 }
 
-                tpInput.step = '0.01';
-                slInput.step = '0.01';
+                // Clear values on mode switch
                 tpInput.value = '';
                 slInput.value = '';
             });
         });
-
-        // Converts a dollar P&L amount to a price offset using market metadata.
-        // Formula matches C++/Python demos: price_distance = (dollars / pointValue) * minTick
-        function calcDollarToPrice(dollarAmt) {
-            const mId = client.currentMarketId;
-            const details = mId ? client.getMarketDetails?.(mId) : null;
-            const pointValue = Number(details?.pointValue?.value ?? details?.point_value?.value ?? 0);
-            const minTick    = Number(details?.minPriceIncrement?.value ?? 0);
-            if (!Number.isFinite(dollarAmt) || pointValue <= 0 || minTick <= 0) return null;
-            return (dollarAmt / pointValue) * minTick;
-        }
 
         // Read the two OCO legs off the form. Shared by submitOrder (single send) and
         // addToBatch (staging), so both build identical leg specs. Validation lives in
@@ -1374,23 +1359,15 @@
                 const stopLossElement = document.getElementById('stopLossPrice');
                 const trailingStopElement = document.getElementById('trailingStopToggle');
 
-                let takeProfit = takeProfitElement && takeProfitElement.value ? parseFloat(takeProfitElement.value) : null;
-                let stopLoss = stopLossElement && stopLossElement.value ? parseFloat(stopLossElement.value) : null;
                 const trailingStop = trailingStopElement ? trailingStopElement.checked : false;
 
-                // 'calculated' mode: convert dollar P&L → price offset via ($/pointValue)*minTick
-                const effectiveBracketMode = bracketMode === 'calculated' ? 'dollars' : bracketMode;
-                if (bracketMode === 'calculated') {
-                    takeProfit = takeProfit !== null ? calcDollarToPrice(takeProfit) : null;
-                    stopLoss   = stopLoss   !== null ? calcDollarToPrice(stopLoss)   : null;
-                    if ((takeProfitElement.value && takeProfit === null) ||
-                        (stopLossElement.value   && stopLoss   === null)) {
-                        log('Calculated Distance: market data (point value / tick size) not yet available.', 'error');
-                        return;
-                    }
-                }
+                // Both modes pass the raw typed value straight through; buildOrderSubmit
+                // does the conversion (dollars → signed AUTO_OCO offset) or takes the
+                // value as an absolute price (AOCO_P). Keeps a single source of truth.
+                const takeProfit = takeProfitElement && takeProfitElement.value ? parseFloat(takeProfitElement.value) : null;
+                const stopLoss   = stopLossElement   && stopLossElement.value   ? parseFloat(stopLossElement.value)   : null;
 
-                await client.submitOrder(side, volume, price, priceType, takeProfit, stopLoss, trailingStop, effectiveBracketMode);
+                await client.submitOrder(side, volume, price, priceType, takeProfit, stopLoss, trailingStop, bracketMode);
             } catch (error) {
                 log(`Order submission error: ${error.message}`, 'error');
             }
@@ -1623,21 +1600,13 @@
             const tpEl = document.getElementById('takeProfitPrice');
             const slEl = document.getElementById('stopLossPrice');
             const trailEl = document.getElementById('trailingStopToggle');
-            let takeProfitDollars = tpEl && tpEl.value ? parseFloat(tpEl.value) : null;
-            let stopLossDollars   = slEl && slEl.value ? parseFloat(slEl.value) : null;
-            const trailingStop    = trailEl ? trailEl.checked : false;
+            const trailingStop = trailEl ? trailEl.checked : false;
 
-            // 'calculated' mode: convert dollar P&L → price offset before staging
-            const effectiveBracketMode = bracketMode === 'calculated' ? 'dollars' : bracketMode;
-            if (bracketMode === 'calculated') {
-                takeProfitDollars = takeProfitDollars !== null ? calcDollarToPrice(takeProfitDollars) : null;
-                stopLossDollars   = stopLossDollars   !== null ? calcDollarToPrice(stopLossDollars)   : null;
-                if ((tpEl.value && takeProfitDollars === null) ||
-                    (slEl.value && stopLossDollars   === null)) {
-                    log('Calculated Distance: market data (point value / tick size) not yet available.', 'error');
-                    return;
-                }
-            }
+            // Stage the raw typed values; buildOrderSubmit converts them at submit time
+            // (dollars → signed AUTO_OCO offset, or absolute price for AOCO_P), so a
+            // staged row matches exactly what submitOrder would send.
+            const takeProfitDollars = tpEl && tpEl.value ? parseFloat(tpEl.value) : null;
+            const stopLossDollars   = slEl && slEl.value ? parseFloat(slEl.value) : null;
 
             batchRows.push({
                 accountId: client.selectedAccount,
@@ -1646,7 +1615,7 @@
                 ...(takeProfitDollars !== null ? { takeProfitDollars } : {}),
                 ...(stopLossDollars   !== null ? { stopLossDollars }   : {}),
                 ...(takeProfitDollars !== null || stopLossDollars !== null
-                    ? { trailingStop, bracketMode: effectiveBracketMode } : {}),
+                    ? { trailingStop, bracketMode } : {}),
             });
             renderBatch();
             const stagedPriceText = priceType === 'market' ? 'Market' : price;

--- a/tools/JavaScript/JSDemo/index.html
+++ b/tools/JavaScript/JSDemo/index.html
@@ -142,17 +142,19 @@
                 <div class="bracket-toggle">
                     <input type="radio" name="bracketMode" id="bracketModeDollars" value="dollars" checked>
                     <label for="bracketModeDollars">Distance</label>
+                    <input type="radio" name="bracketMode" id="bracketModeCalc" value="calculated">
+                    <label for="bracketModeCalc">Calculated Distance</label>
                     <input type="radio" name="bracketMode" id="bracketModePrice" value="price">
                     <label for="bracketModePrice">Price (AOCO_P)</label>
                 </div>
             </div>
             <div class="form-group">
                 <label for="takeProfitPrice" id="takeProfitLabel">Take Profit (Distance in Dollars):</label>
-                <input type="number" id="takeProfitPrice" step="0.01" placeholder="Optional">
+                <input type="number" id="takeProfitPrice" step="0.01" placeholder="Dollar distance">
             </div>
             <div class="form-group">
                 <label for="stopLossPrice" id="stopLossLabel">Stop Loss (Distance in Dollars):</label>
-                <input type="number" id="stopLossPrice" step="0.01" placeholder="Optional">
+                <input type="number" id="stopLossPrice" step="0.01" placeholder="Dollar distance">
                 <div class="trailing-toggle">
                     <input type="checkbox" id="trailingStopToggle">
                     <label for="trailingStopToggle">Trailing</label>
@@ -1295,24 +1297,37 @@
                 if (mode === 'dollars') {
                     tpLabel.textContent = 'Take Profit (Distance in Dollars):';
                     slLabel.textContent = 'Stop Loss (Distance in Dollars):';
-                    tpInput.step = '0.01';
-                    slInput.step = '0.01';
                     tpInput.placeholder = 'Dollar distance';
                     slInput.placeholder = 'Dollar distance';
+                } else if (mode === 'calculated') {
+                    tpLabel.textContent = 'Take Profit (Calculated Distance):';
+                    slLabel.textContent = 'Stop Loss (Calculated Distance):';
+                    tpInput.placeholder = 'Dollar P&L → price offset';
+                    slInput.placeholder = 'Dollar P&L → price offset';
                 } else {
                     tpLabel.textContent = 'Take Profit (Price):';
                     slLabel.textContent = 'Stop Loss (Price):';
-                    tpInput.step = '0.01';
-                    slInput.step = '0.01';
                     tpInput.placeholder = 'Absolute price';
                     slInput.placeholder = 'Absolute price';
                 }
 
-                // Clear values on mode switch
+                tpInput.step = '0.01';
+                slInput.step = '0.01';
                 tpInput.value = '';
                 slInput.value = '';
             });
         });
+
+        // Converts a dollar P&L amount to a price offset using market metadata.
+        // Formula matches C++/Python demos: price_distance = (dollars / pointValue) * minTick
+        function calcDollarToPrice(dollarAmt) {
+            const mId = client.currentMarketId;
+            const details = mId ? client.getMarketDetails?.(mId) : null;
+            const pointValue = Number(details?.pointValue?.value ?? details?.point_value?.value ?? 0);
+            const minTick    = Number(details?.minPriceIncrement?.value ?? 0);
+            if (!Number.isFinite(dollarAmt) || pointValue <= 0 || minTick <= 0) return null;
+            return (dollarAmt / pointValue) * minTick;
+        }
 
         // Read the two OCO legs off the form. Shared by submitOrder (single send) and
         // addToBatch (staging), so both build identical leg specs. Validation lives in
@@ -1359,11 +1374,23 @@
                 const stopLossElement = document.getElementById('stopLossPrice');
                 const trailingStopElement = document.getElementById('trailingStopToggle');
 
-                const takeProfit = takeProfitElement && takeProfitElement.value ? parseFloat(takeProfitElement.value) : null;
-                const stopLoss = stopLossElement && stopLossElement.value ? parseFloat(stopLossElement.value) : null;
+                let takeProfit = takeProfitElement && takeProfitElement.value ? parseFloat(takeProfitElement.value) : null;
+                let stopLoss = stopLossElement && stopLossElement.value ? parseFloat(stopLossElement.value) : null;
                 const trailingStop = trailingStopElement ? trailingStopElement.checked : false;
 
-                await client.submitOrder(side, volume, price, priceType, takeProfit, stopLoss, trailingStop, bracketMode);
+                // 'calculated' mode: convert dollar P&L → price offset via ($/pointValue)*minTick
+                const effectiveBracketMode = bracketMode === 'calculated' ? 'dollars' : bracketMode;
+                if (bracketMode === 'calculated') {
+                    takeProfit = takeProfit !== null ? calcDollarToPrice(takeProfit) : null;
+                    stopLoss   = stopLoss   !== null ? calcDollarToPrice(stopLoss)   : null;
+                    if ((takeProfitElement.value && takeProfit === null) ||
+                        (stopLossElement.value   && stopLoss   === null)) {
+                        log('Calculated Distance: market data (point value / tick size) not yet available.', 'error');
+                        return;
+                    }
+                }
+
+                await client.submitOrder(side, volume, price, priceType, takeProfit, stopLoss, trailingStop, effectiveBracketMode);
             } catch (error) {
                 log(`Order submission error: ${error.message}`, 'error');
             }
@@ -1596,9 +1623,21 @@
             const tpEl = document.getElementById('takeProfitPrice');
             const slEl = document.getElementById('stopLossPrice');
             const trailEl = document.getElementById('trailingStopToggle');
-            const takeProfitDollars = tpEl && tpEl.value ? parseFloat(tpEl.value) : null;
-            const stopLossDollars   = slEl && slEl.value ? parseFloat(slEl.value) : null;
-            const trailingStop      = trailEl ? trailEl.checked : false;
+            let takeProfitDollars = tpEl && tpEl.value ? parseFloat(tpEl.value) : null;
+            let stopLossDollars   = slEl && slEl.value ? parseFloat(slEl.value) : null;
+            const trailingStop    = trailEl ? trailEl.checked : false;
+
+            // 'calculated' mode: convert dollar P&L → price offset before staging
+            const effectiveBracketMode = bracketMode === 'calculated' ? 'dollars' : bracketMode;
+            if (bracketMode === 'calculated') {
+                takeProfitDollars = takeProfitDollars !== null ? calcDollarToPrice(takeProfitDollars) : null;
+                stopLossDollars   = stopLossDollars   !== null ? calcDollarToPrice(stopLossDollars)   : null;
+                if ((tpEl.value && takeProfitDollars === null) ||
+                    (slEl.value && stopLossDollars   === null)) {
+                    log('Calculated Distance: market data (point value / tick size) not yet available.', 'error');
+                    return;
+                }
+            }
 
             batchRows.push({
                 accountId: client.selectedAccount,
@@ -1607,7 +1646,7 @@
                 ...(takeProfitDollars !== null ? { takeProfitDollars } : {}),
                 ...(stopLossDollars   !== null ? { stopLossDollars }   : {}),
                 ...(takeProfitDollars !== null || stopLossDollars !== null
-                    ? { trailingStop, bracketMode } : {}),
+                    ? { trailingStop, bracketMode: effectiveBracketMode } : {}),
             });
             renderBatch();
             const stagedPriceText = priceType === 'market' ? 'Market' : price;

--- a/tools/JavaScript/JSDemo/index.html
+++ b/tools/JavaScript/JSDemo/index.html
@@ -147,11 +147,11 @@
                 </div>
             </div>
             <div class="form-group">
-                <label for="takeProfitPrice" id="takeProfitLabel">Take Profit (Distance):</label>
+                <label for="takeProfitPrice" id="takeProfitLabel">Take Profit (Distance in Dollars):</label>
                 <input type="number" id="takeProfitPrice" step="0.01" placeholder="Optional">
             </div>
             <div class="form-group">
-                <label for="stopLossPrice" id="stopLossLabel">Stop Loss (Distance):</label>
+                <label for="stopLossPrice" id="stopLossLabel">Stop Loss (Distance in Dollars):</label>
                 <input type="number" id="stopLossPrice" step="0.01" placeholder="Optional">
                 <div class="trailing-toggle">
                     <input type="checkbox" id="trailingStopToggle">
@@ -1293,12 +1293,12 @@
                 const slInput = document.getElementById('stopLossPrice');
 
                 if (mode === 'dollars') {
-                    tpLabel.textContent = 'Take Profit (Distance):';
-                    slLabel.textContent = 'Stop Loss (Distance):';
+                    tpLabel.textContent = 'Take Profit (Distance in Dollars):';
+                    slLabel.textContent = 'Stop Loss (Distance in Dollars):';
                     tpInput.step = '0.01';
                     slInput.step = '0.01';
-                    tpInput.placeholder = 'Price distance';
-                    slInput.placeholder = 'Price distance';
+                    tpInput.placeholder = 'Dollar distance';
+                    slInput.placeholder = 'Dollar distance';
                 } else {
                     tpLabel.textContent = 'Take Profit (Price):';
                     slLabel.textContent = 'Stop Loss (Price):';


### PR DESCRIPTION
Dollars-mode bracket TP/SL now sends the typed value as a raw price distance off the fill (signed by side) as the AUTO_OCO offset, instead of scaling it through point value / decimals — so the protective orders land at the intended distance. Mode relabeled to "Distance"; Price mode (AOCO_P, absolute prices) unchanged.